### PR TITLE
Custom configuration hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ As an example, the following command configures a mail server
 - The domain "example.com" is accepted as final destination with the
   default configuration for the SMTP MX server, listening on port 25.
 
+## Custom configuration
+
+**Dovecot** custom configuration is saved in the `dovecot-custom` volume.
+To edit it, run this command while `dovecot.service` is running:
+
+    podman exec -ti dovecot vi /etc/dovecot/local.conf.d/myoverride.conf
+    systemctl --user reload dovecot
+
+If the service is stopped, start a dedicated container to mount the volume
+properly:
+
+    podman run --rm -ti -v dovecot-custom:/srv:z alpine vi /srv/myoverride.conf
+    systemctl --user reload dovecot
+
+For **Postfix** the commands are similar. Custom configuration is saved in
+the `postfix-custom` volume. Edit it with:
+
+    podman exec -ti postfix vi /etc/postfix/main.cf.d/myoverride.cf
+    systemctl --user reload postfix
+
+If Postfix is stopped run this one instead:
+
+    podman run --rm -ti -v postfix-custom:/srv:z alpine vi /srv/myoverride.cf
+    systemctl --user reload postfix
+
+After applying a custom configuration, check the services are running properly:
+
+    systemctl --user status postfix dovecot
+
 ## User impersonation
 
 The username `vmail` is reserved and granted the *impersonate* privilege.

--- a/dovecot/README.md
+++ b/dovecot/README.md
@@ -97,6 +97,9 @@ Volumes are:
   process through Unix-domain sockets. Contents
      * `lmtp`, the Message Delivery Agent (MDA) Unix-domain
      * `auth`, Dovecot/Postfix SASL integration
+- `/etc/dovecot/local.conf.d`. Local configuration override volume. Any
+  `.conf` file added to this directory is included into Dovecot
+  configuration after `local.conf` contents.
 
 ## Custom user quota
 

--- a/dovecot/etc/dovecot/local.conf.d/README
+++ b/dovecot/etc/dovecot/local.conf.d/README
@@ -1,0 +1,4 @@
+Local configuration override
+----------------------------
+
+Any *.conf file in this directory is appended to local.conf

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -194,3 +194,6 @@ userdb {
   args = /etc/dovecot/userdb.conf.ext
 }
 # end of pass/user db configuration
+
+# Include /etc/dovecot/local.conf.d/ contents:
+!include /etc/dovecot/local.conf.d/*.conf

--- a/imageroot/systemd/user/dovecot.service
+++ b/imageroot/systemd/user/dovecot.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/podman run \
     --volume=dovecot-cert:/etc/ssl/dovecot:z \
     --volume=dovecot-dict:/var/lib/dovecot/dict:z \
     --volume=dovecot-lmtp:/var/lib/umail:z \
+    --volume=dovecot-custom:/etc/dovecot/local.conf.d:z \
     ${MAIL_DOVECOT_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/dovecot.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/dovecot.ctr-id

--- a/imageroot/systemd/user/postfix.service
+++ b/imageroot/systemd/user/postfix.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/podman run \
     --volume=postfix-queue:/var/spool/postfix:z \
     --volume=dovecot-lmtp:/var/lib/umail:z \
     --volume=/dev/log:/dev/log \
+    --volume=postfix-custom:/etc/postfix/main.cf.d:z \
     ${MAIL_POSTFIX_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/postfix.ctr-id -t 10
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/postfix.ctr-id

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -47,6 +47,9 @@ Standard public TCP ports
   process through Unix-domain sockets. Mount the Dovecot container path
   where `lmtp` and `auth` sockets reside. It is possible to not mount this
   volume path to disable all Dovecot integrations.
+- `/etc/postfix/main.cf.d`. Local configuration override volume. Any `.cf`
+  file added to this directory is always appended to the expanded
+  `main.cf` file.
 
 ## Commands
 

--- a/postfix/etc/postfix/main.cf.d/README
+++ b/postfix/etc/postfix/main.cf.d/README
@@ -1,0 +1,4 @@
+Local configuration override
+----------------------------
+
+Any *.cf file in this directory is appended to main.cf

--- a/postfix/usr/local/bin/reload-config
+++ b/postfix/usr/local/bin/reload-config
@@ -85,6 +85,15 @@ if [ -z "${tmpl_sasl_commentout}" ] ; then
     cat /etc/postfix/dovecot-sasl.cf >> /etc/postfix/main.cf
 fi
 
+# Append override dir contents to main.cf:
+(
+    echo ""
+    echo "# BEGIN Included directives from /etc/postfix/main.cf.d/*.cf:"
+    find /etc/postfix/main.cf.d -name '*.cf' -exec cat '{}' \;
+    echo "# END Included directives from /etc/postfix/main.cf.d/*.cf:"
+    echo ""
+) >> /etc/postfix/main.cf
+
 if [ -n "${POSTFIX_DEBUG}" ] ; then
     postconf -n
 fi


### PR DESCRIPTION
Store custom Postfix and Dovecot configuration in a service volume and include it to
override the standard configuration.

Document an example procedure to modify the standard configuration. Podman version 4+ has more options to modify a volume contents without running a full container. The documented procedure should be compatible with older versions.