### PR TITLE
UI: minor fixes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@carbon/icons-vue": "^10.37.0",
     "@carbon/vue": "^2.40.0",
-    "@nethserver/ns8-ui-lib": "^0.1.9",
+    "@nethserver/ns8-ui-lib": "^0.1.12",
     "await-to-js": "^3.0.0",
     "axios": "^0.21.2",
     "carbon-components": "^10.41.0",

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -159,7 +159,8 @@
     "type_wildcard": "Wildcard",
     "type_domain": "Alias",
     "type_adduser": "User",
-    "type_addgroup": "Group"
+    "type_addgroup": "Group",
+    "address_already_exists": "Address already exists"
   },
   "mailboxes": {
     "title": "Mailboxes",
@@ -224,7 +225,8 @@
     "unlimited_quota_using_usage": "Unlimited quota, using {usage}",
     "disable_mailbox": "Disable mailbox",
     "confirm_disable_mailbox": "Do you really want to disable mailbox <strong>{mailbox}</strong>?",
-    "confirm_disable_mailbox_2": "It will stop receiving messages and you won't be able to select it as address destination"
+    "confirm_disable_mailbox_2": "It will stop receiving messages and you won't be able to select it as address destination",
+    "address_already_exists": "Address already exists"
   },
   "settings_mailboxes": {
     "title": "Mailboxes",

--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -1,21 +1,17 @@
 {
   "name": "Mail",
   "description": {
-    "en": "Mail module with SMTP, IMAP, spam and virus filter"
+    "en": "Manage a complete mail server with ease and security"
   },
-  "categories": [],
+  "categories": ["collaboration"],
   "authors": [
     {
-      "name": "Davide Principi",
-      "email": "davide.principi@nethesis.it"
-    },
-    {
-      "name": "Andrea Leardini",
-      "email": "andrea.leardini@nethesis.it"
+      "name": "NethServer team",
+      "email": "nethserver@nethesis.it"
     }
   ],
   "docs": {
-    "documentation_url": "https://docs.mail.com/",
+    "documentation_url": "https://github.com/NethServer/ns8-mail",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-mail"
   },

--- a/ui/src/components/CreateOrEditAddressModal.vue
+++ b/ui/src/components/CreateOrEditAddressModal.vue
@@ -91,6 +91,7 @@
           :maxDisplayOptions="100"
           acceptUserInput
           showItemType
+          showItemDescription
           selectedItemsColor="high-contrast"
           :options="allDestinationsForUi"
           class="mg-bottom-12"
@@ -496,8 +497,9 @@ export default {
         return {
           name: d.name,
           value: `${d.name}_${d.dtype}`,
-          label: d.ui_name || d.name,
+          label: d.name,
           type: this.$t(`common.${d.dtype}_destination`),
+          description: d.ui_name,
         };
       });
 

--- a/ui/src/components/FirstConfigurationModal.vue
+++ b/ui/src/components/FirstConfigurationModal.vue
@@ -168,6 +168,8 @@ export default {
     },
     isNextButtonDisabled() {
       return (
+        this.loading.getDefaults ||
+        !this.userDomains.length ||
         this.loading.configureModule ||
         (this.step == "mailHostname" &&
           (!this.hostname || !this.mail_domain)) ||

--- a/ui/src/components/mailboxes/CreateOrEditPublicMailboxModal.vue
+++ b/ui/src/components/mailboxes/CreateOrEditPublicMailboxModal.vue
@@ -79,6 +79,7 @@
           userInputLabel=""
           :maxDisplayOptions="100"
           showItemType
+          showItemDescription
           selectedItemsColor="high-contrast"
           :options="allAclSubjectsForUi"
           ref="acl"
@@ -528,8 +529,9 @@ export default {
         return {
           name: d.name,
           value: `${d.name}_${d.dtype}`,
-          label: d.ui_name || d.name,
+          label: d.name,
           type: this.$t(`common.${d.dtype}_destination`),
+          description: d.ui_name
         };
       });
 

--- a/ui/src/components/mailboxes/EditUserMailboxModal.vue
+++ b/ui/src/components/mailboxes/EditUserMailboxModal.vue
@@ -61,6 +61,7 @@
             :maxDisplayOptions="100"
             acceptUserInput
             showItemType
+            showItemDescription
             selectedItemsColor="high-contrast"
             :options="forward.allDestinationsForUi"
           />
@@ -546,8 +547,9 @@ export default {
           return {
             name: d.name,
             value: `${d.name}_${d.dtype}`,
-            label: d.ui_name || d.name,
+            label: d.name,
             type: this.$t(`common.${d.dtype}_destination`),
+            description: d.ui_name,
           };
         }
       );

--- a/ui/src/components/mailboxes/UserMailboxes.vue
+++ b/ui/src/components/mailboxes/UserMailboxes.vue
@@ -155,6 +155,7 @@
                     <cv-overflow-menu-item
                       @click="showEditUserMailboxModal(row)"
                       :data-test-id="row.user + '-edit'"
+                      :disabled="row.enabled == false"
                     >
                       <NsMenuItem
                         :icon="Edit20"

--- a/ui/src/views/Status.vue
+++ b/ui/src/views/Status.vue
@@ -44,7 +44,11 @@
         <cv-column :md="4" :max="4">
           <NsInfoCard
             light
-            :title="configuration ? configuration.hostname : '-'"
+            :title="
+              configuration && configuration.hostname
+                ? configuration.hostname
+                : '-'
+            "
             :description="$t('status.mail_hostname')"
             :icon="BareMetalServer32"
             :loading="!configuration"
@@ -54,7 +58,11 @@
         <cv-column :md="4" :max="4">
           <NsInfoCard
             light
-            :title="configuration ? configuration.user_domain.name : '-'"
+            :title="
+              configuration && configuration.user_domain
+                ? configuration.user_domain.name
+                : '-'
+            "
             :description="$t('status.user_domain')"
             :icon="Events32"
             :loading="!configuration"

--- a/ui/src/views/settings/SettingsMasterUsers.vue
+++ b/ui/src/views/settings/SettingsMasterUsers.vue
@@ -97,6 +97,7 @@
                     userInputLabel=""
                     :maxDisplayOptions="100"
                     :showItemType="false"
+                    :showItemDescription="false"
                     selectedItemsColor="high-contrast"
                     :options="allMailboxesForUi"
                   />

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1012,10 +1012,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@nethserver/ns8-ui-lib@^0.1.9":
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-0.1.9.tgz#df3e55e2a9ff85cb863bf8fb8ced2b2da517e694"
-  integrity sha512-g6SvPQUpf2GyUi97RrfANws8otYgsIE/9/llRdacm4XB+g0oNa7pPrHe/jPQDwai3xmH2D3x8DfSggDXc9Y62Q==
+"@nethserver/ns8-ui-lib@^0.1.12":
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/@nethserver/ns8-ui-lib/-/ns8-ui-lib-0.1.12.tgz#608663234435727173ff95a66ab004c03a6305f0"
+  integrity sha512-JnqaPyfEG3F3x6daSByOjnFZoJwkR34GBvxhA9jX0hUhWlOGnHb4UpUOHr6Zh0wf2Gt8bCbxVXKlFq18qPPEfQ==
   dependencies:
     "@rollup/plugin-json" "^4.1.0"
     core-js "^3.15.2"


### PR DESCRIPTION
- Align `metadata.json` to `ns8-rempomd` data
- First configuration modal: disable **Next** button if there is no user domain configured
- User mailbox cannot be edited if it is disabled
- Add missing i18n strings
- Show items description in some `NsMultiSelect` components

![image](https://user-images.githubusercontent.com/4612169/187168219-3c8a9e0b-855c-48fd-a673-b70781f50cc6.png)
