### PR TITLE
Publish MSA port 10587

### DIFF
--- a/imageroot/actions/configure-module/90publish_srv_keys
+++ b/imageroot/actions/configure-module/90publish_srv_keys
@@ -33,7 +33,7 @@ with agent.redis_connect(privileged=True) as prdb:
 
     ksubmission = agent_id + "/srv/tcp/submission"
     trx.delete(ksubmission).hset(ksubmission, mapping={
-        "port": "587",
+        "port": "10587",
         "host": node_address,
         "node": str(node_id),
         "user_domain": udomname,

--- a/imageroot/update-module.d/80restart_services
+++ b/imageroot/update-module.d/80restart_services
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+
+systemctl --user try-restart \
+    dovecot.service \
+    postfix.service \
+    rspamd.service \
+    clamav.service

--- a/imageroot/update-module.d/90publish_srv_keys
+++ b/imageroot/update-module.d/90publish_srv_keys
@@ -1,0 +1,1 @@
+../actions/configure-module/90publish_srv_keys


### PR DESCRIPTION
Invite other applications to submit messages through port 10587 which
does not enforce AUTH over TLS.

Restart services and update srv records: when the module is updated, start the new service images.

See also 

- https://github.com/NethServer/dev/issues/5672
- https://github.com/NethServer/ns8-mail/commit/8b9bdd4bc7ca549d33aba37179ffe69d69ca8709

Rebase-merge