### PR TITLE
Do not raise mail-settings-changed

### DIFF
--- a/imageroot/actions/destroy-module/20cleanup_srv_keys
+++ b/imageroot/actions/destroy-module/20cleanup_srv_keys
@@ -25,12 +25,4 @@ with agent.redis_connect(privileged=True) as prdb:
     ksubmission = agent_id + "/srv/tcp/submission"
     trx.delete(ksubmission)
 
-    # Publish change event
-    trx.publish(agent_id + "/event/mail-settings-changed", json.dumps({
-        "reason": os.getenv("AGENT_TASK_ACTION", "unknown"),
-        "module_id": os.environ['MODULE_ID'],
-        "node_id": node_id,
-        "module_uuid": module_uuid,
-    }))
-
     trx.execute()


### PR DESCRIPTION
When Mail is removed, the core already publishes the module-removed event.
This action actually does not change the mail settings: it removes them! The only thing a listener can do is knowing that its Mail module disappeared.