### PR TITLE
Fix the integer fallback value

### DIFF
--- a/imageroot/bin/discover-services
+++ b/imageroot/bin/discover-services
@@ -26,7 +26,7 @@ except:
     # Once the domain becomes available, the event will fix them.
     odom = {
         'host': '127.0.0.1',
-        'port': 0,
+        'port': '0',
         'schema': 'rfc2307',
         'location': 'internal',
         'base_dn': 'dc=dovecot,dc=invalid',


### PR DESCRIPTION
When I run the discover-service without domain I have

bash-5.1$ ../bin/discover-ldap 
Traceback (most recent call last):
  File "/home/ejabberd3/.config/state/../bin/discover-services", line 40, in <module>
    print('DOVECOT_LDAP_PORT=' + odom['port'], file=denv)
TypeError: can only concatenate str (not "int") to str

As the Ldapproxy library returns a string value, this PR changes the fallback type to string.