### PR TITLE
Rspamd X-Rspamd-Flag-Threshold header for Webtop

### DIFF
--- a/rspamd/etc/rspamd/local.d/milter_headers.conf
+++ b/rspamd/etc/rspamd/local.d/milter_headers.conf
@@ -4,3 +4,17 @@
 
 # Always add spam scores to inbound messages:
 extended_spam_headers = true;
+
+# Enable custom header for Webtop
+use = ["x_rspamd_flag_threshold"];
+
+custom {
+    # Additional header used by mail clients (i.e. Webtop) to compute the
+    # value of their spam indicator
+    x_rspamd_flag_threshold = <<EOD
+return function(task, common_meta)
+    local flag_threshold = rspamd_config:get_metric_action('add header');
+    return nil, {["X-Rspamd-Flag-Threshold"] = tostring(flag_threshold)}, {["X-Rspamd-Flag-Threshold"] = 0}, {};
+end
+EOD;
+}


### PR DESCRIPTION
Additional header used by mail clients (i.e. Webtop) to compute the value of their spam indicator.

Integer value:

    X-Rspamd-Flag-Threshold: 6

Decimal value:

    X-Rspamd-Flag-Threshold: 6.12

----

See also upstream issue here: https://sonicle.atlassian.net/browse/WT-1229

