### PR TITLE
quota is undefined when mailbox is disabled

### DIFF
--- a/ui/src/components/mailboxes/UserMailboxes.vue
+++ b/ui/src/components/mailboxes/UserMailboxes.vue
@@ -384,10 +384,14 @@ export default {
       // sort by quota
 
       return function (a, b) {
-        if (a.quota.value < b.quota.value) {
+        //we might have some undefined quota property
+        let varA = a.quota || { quota: {} };
+        let varB = b.quota || { quota: {} };
+
+        if (varA.value < varB.value) {
           return -1;
         }
-        if (a.quota.value > b.quota.value) {
+        if (varA.value > varB.value) {
           return 1;
         }
         return 0;

--- a/ui/src/components/mailboxes/UserMailboxes.vue
+++ b/ui/src/components/mailboxes/UserMailboxes.vue
@@ -385,8 +385,8 @@ export default {
 
       return function (a, b) {
         //we might have some undefined quota property
-        let varA = a.quota || { quota: {} };
-        let varB = b.quota || { quota: {} };
+        let varA = a.quota || {};
+        let varB = b.quota || {};
 
         if (varA.value < varB.value) {
           return -1;


### PR DESCRIPTION
When we disabled the mailbox of a user, the sort function is broken because the quota property object is undefined

```
bash-5.1$ /home/mail2/.config/actions/list-user-mailboxes/10list_user_mailboxes | jq
{
  "default_spam_retention": {
    "value": 15
  },
  "user_mailboxes": [
    {
      "user": "ef",
      "enabled": false
    },
    {
      "user": "administrator",
      "quota": {
        "limit": 0,
        "value": 0,
        "percent": 0
      }
    },
    {
      "user": "ab",
      "quota": {
        "limit": 0,
        "value": 8,
        "percent": 0
      }
    },
    ]
}
```

https://trello.com/c/N4BrjtgW/388-mail-p2-sorting-does-not-work-in-mailboxes