### PR TITLE
Dovecot SharedSeen property, enabled by default

### DIFF
--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -28,7 +28,7 @@ doveadm_api_key=${DOVECOT_API_KEY:?}
 doveadm_api_port=${DOVECOT_API_PORT:?}
 stats_http_port=${DOVECOT_METRICS_PORT:?}
 tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
-tmpl_sharedseen=$([[ ${DOVECOT_SHAREDSEEN:-True} == 'False' ]] && echo ':INDEXPVT=~/Maildir/shared/%%u' || echo '')
+tmpl_sharedseen=${DOVECOT_SHAREDSEEN:-:INDEXPVT=~/Maildir/shared/%%n}
 tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
 tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
 tmpl_mail_plugins="acl listescape notify mail_log"

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -28,7 +28,6 @@ doveadm_api_key=${DOVECOT_API_KEY:?}
 doveadm_api_port=${DOVECOT_API_PORT:?}
 stats_http_port=${DOVECOT_METRICS_PORT:?}
 tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
-tmpl_sharedseen=${DOVECOT_SHAREDSEEN:-:INDEXPVT=~/Maildir/shared/%%n}
 tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
 tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
 tmpl_mail_plugins="acl listescape notify mail_log"
@@ -49,6 +48,13 @@ if [ -n "${DOVECOT_SPAM_FOLDER}" ]; then
     tmpl_spam_folder_auto="subscribe"
 else
     tmpl_spam_folder_auto="no"
+fi
+
+# shared seen empty is false, true is non empty
+if [ -n "${DOVECOT_SHAREDSEEN}" ];then
+    tmpl_sharedseen=""
+else
+    tmpl_sharedseen=":INDEXPVT=~/Maildir/shared/%%n"
 fi
 
 master_users=${DOVECOT_MASTER_USERS}

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -28,7 +28,7 @@ doveadm_api_key=${DOVECOT_API_KEY:?}
 doveadm_api_port=${DOVECOT_API_PORT:?}
 stats_http_port=${DOVECOT_METRICS_PORT:?}
 tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
-tmpl_sharedseen=$([[ ${DOVECOT_SHAREDSEEN:-disabled} == 'disabled' ]] && echo ':INDEXPVT=~/Maildir/shared/%%u' || echo '')
+tmpl_sharedseen=$([[ ${DOVECOT_SHAREDSEEN:-enabled} == 'disabled' ]] && echo ':INDEXPVT=~/Maildir/shared/%%u' || echo '')
 tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
 tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
 tmpl_mail_plugins="acl listescape notify mail_log"

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -28,7 +28,7 @@ doveadm_api_key=${DOVECOT_API_KEY:?}
 doveadm_api_port=${DOVECOT_API_PORT:?}
 stats_http_port=${DOVECOT_METRICS_PORT:?}
 tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
-tmpl_sharedseen=$([[ ${DOVECOT_SHAREDSEEN:-enabled} == 'disabled' ]] && echo ':INDEXPVT=~/Maildir/shared/%%u' || echo '')
+tmpl_sharedseen=$([[ ${DOVECOT_SHAREDSEEN:-True} == 'False' ]] && echo ':INDEXPVT=~/Maildir/shared/%%u' || echo '')
 tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
 tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
 tmpl_mail_plugins="acl listescape notify mail_log"

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -28,6 +28,7 @@ doveadm_api_key=${DOVECOT_API_KEY:?}
 doveadm_api_port=${DOVECOT_API_PORT:?}
 stats_http_port=${DOVECOT_METRICS_PORT:?}
 tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
+tmpl_sharedseen=$([[ ${DOVECOT_SHAREDSEEN:-disabled} == 'disabled' ]] && echo ':INDEXPVT=~/Maildir/shared/%%u' || echo '')
 tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
 tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
 tmpl_mail_plugins="acl listescape notify mail_log"

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -56,7 +56,7 @@ namespace inbox {
   }
 }
 namespace SHARED_USERS {
-  location = maildir:/var/lib/vmail/%%n/Maildir:INDEXPVT=~/Maildir/shared/%%n
+  location = maildir:/var/lib/vmail/%%n/Maildir${tmpl_sharedseen}
   type = shared
   disabled = no
   separator = /

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -48,6 +48,9 @@ if not 'DOVECOT_QUOTA_MB' in os.environ:
     agent.set_env('DOVECOT_SPAM_FOLDER', 'Junk') # Default spam folder name, enabled
     agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', '') # Default spam subject prefix: empty - disabled
 
+if not 'DOVECOT_SHAREDSEEN' in os.environ:
+    agent.set_env('DOVECOT_SHAREDSEEN', "1") # enable DOVECOT_SHAREDSEEN by default
+
 if not 'CLAMAV_CUS_RATING' in os.environ:
     # Initial value for default_dbs_rating parameter of clamav-unofficial-sigs
     agent.set_env('CLAMAV_CUS_RATING', 'MEDIUM')

--- a/imageroot/actions/get-mailbox-settings/10get_mailbox_settings
+++ b/imageroot/actions/get-mailbox-settings/10get_mailbox_settings
@@ -39,8 +39,13 @@ if os.getenv("DOVECOT_SPAM_FOLDER"):
         "name": os.getenv("DOVECOT_SPAM_FOLDER"),
     }
 
+osharedseen = {
+    "enabled": os.getenv("DOVECOT_SHAREDSEEN", 'True') == "True"
+}
+
 json.dump({
     "quota": oquota,
     "spam_retention": ospam_retention,
     "spam_folder": ospam_folder,
+    "sharedseen": osharedseen,
 }, fp=sys.stdout)

--- a/imageroot/actions/get-mailbox-settings/10get_mailbox_settings
+++ b/imageroot/actions/get-mailbox-settings/10get_mailbox_settings
@@ -40,7 +40,7 @@ if os.getenv("DOVECOT_SPAM_FOLDER"):
     }
 
 osharedseen = {
-    "enabled": os.getenv("DOVECOT_SHAREDSEEN", 'True') == "True"
+    "enabled": os.getenv("DOVECOT_SHAREDSEEN", '') != ""
 }
 
 json.dump({

--- a/imageroot/actions/get-mailbox-settings/validate-output.json
+++ b/imageroot/actions/get-mailbox-settings/validate-output.json
@@ -14,6 +14,9 @@
             },
             "quota": {
                 "limit": 2000
+            },
+            "sharedseen": {
+                "enabled": true
             }
         },
         {
@@ -25,6 +28,9 @@
             },
             "quota": {
                 "limit": 0
+            },
+            "sharedseen": {
+                "enabled": false
             }
         }
     ],
@@ -33,7 +39,8 @@
     "required": [
         "spam_retention",
         "spam_folder",
-        "quota"
+        "quota",
+        "sharedseen"
     ],
     "properties": {
         "spam_folder": {
@@ -44,6 +51,9 @@
         },
         "quota": {
             "$ref": "http://schema.nethserver.org/mail.json#/$defs/quota-status"
+        },
+        "sharedseen": {
+            "$ref": "http://schema.nethserver.org/mail.json#/$defs/sharedseen-status"
         }
     }
 }

--- a/imageroot/actions/set-mailbox-settings/10set_mailbox_settings
+++ b/imageroot/actions/set-mailbox-settings/10set_mailbox_settings
@@ -27,3 +27,7 @@ if 'spam_folder' in request:
 if 'spam_retention' in request:
     spam_retention = int(request['spam_retention']['value'])
     agent.set_env("DOVECOT_SPAM_RETENTION", spam_retention)
+
+if 'sharedseen' in request:
+    sharedseen = request['sharedseen']['enabled']
+    agent.set_env("DOVECOT_SHAREDSEEN", sharedseen)

--- a/imageroot/actions/set-mailbox-settings/10set_mailbox_settings
+++ b/imageroot/actions/set-mailbox-settings/10set_mailbox_settings
@@ -30,4 +30,4 @@ if 'spam_retention' in request:
 
 if 'sharedseen' in request:
     sharedseen = request['sharedseen']['enabled']
-    agent.set_env("DOVECOT_SHAREDSEEN", sharedseen)
+    agent.set_env("DOVECOT_SHAREDSEEN", "1" if sharedseen else "")

--- a/imageroot/actions/set-mailbox-settings/validate-input.json
+++ b/imageroot/actions/set-mailbox-settings/validate-input.json
@@ -14,6 +14,9 @@
             },
             "quota": {
                 "limit": 2000
+            },
+            "sharedseen": {
+                "enabled": true
             }
         }
     ],
@@ -28,6 +31,9 @@
         },
         "quota": {
             "$ref": "http://schema.nethserver.org/mail.json#/$defs/quota-status"
+        },
+        "sharedseen": {
+            "$ref": "http://schema.nethserver.org/mail.json#/$defs/sharedseen-status"
         }
     }
 }

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -495,6 +495,20 @@
                 }
             }
         },
+        "sharedseen-status": {
+            "type": "object",
+            "title": "SharedSeen status",
+            "description": "SharedSeen configuration",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "description": "Defines if SharedSeen is enabled or disabled",
+                    "type": "boolean"
+                }
+            }
+        },
         "forward": {
             "type": "object",
             "title": "Forward settings",
@@ -799,7 +813,9 @@
                     "type": "object",
                     "title": "Greylist",
                     "description": "Greylist configuration",
-                    "required": ["enabled"],
+                    "required": [
+                        "enabled"
+                    ],
                     "properties": {
                         "enabled": {
                             "description": "Defines if greylist is enabled",
@@ -815,7 +831,9 @@
                     "type": "object",
                     "title": "Prefix email subject",
                     "description": "Configure if the subject of spam messages are prefixed with a string",
-                    "required": ["enabled"],
+                    "required": [
+                        "enabled"
+                    ],
                     "properties": {
                         "enabled": {
                             "description": "Defines if email subject prefixing",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -322,7 +322,9 @@
     "specify_quota": "Specify quota",
     "move_spam_but_no_folder": "If \"Move spam to junk folder\" is enabled, junk folder name is required",
     "quota": "Quota",
-    "spam": "Spam"
+    "spam": "Spam",
+    "sharedseen": "Shared seen",
+    "sharedseen_explanation_tooltips": "In a shared mailbox, each user has their copy of the messages they have read, however  if you want to know if a mail has already been read by someone else, you could enable this option for all shared mailboxes"
   },
   "settings_master_users": {
     "title": "Master users",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -323,6 +323,7 @@
     "move_spam_but_no_folder": "If \"Move spam to junk folder\" is enabled, junk folder name is required",
     "quota": "Quota",
     "spam": "Spam",
+    "shared_mailboxes": "Shared mailboxes",
     "sharedseen": "Shared seen",
     "sharedseen_explanation_tooltips": "If enabled, a message is marked seen (read) by the first user that opens it, with effect for everyone else sharing the same mailbox"
   },

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -120,8 +120,17 @@
                     :disabled="
                       loading.getMailboxSettings || loading.setMailboxSettings
                     "
-                    :class="toggle-without-label"
+                    :class="toggle - without - label"
                   >
+                    <template slot="tooltip">
+                      <span
+                        v-html="
+                          $t(
+                            'settings_mailboxes.sharedseen_explanation_tooltips'
+                          )
+                        "
+                      ></span>
+                    </template>
                     <template slot="text-left">{{
                       $t("common.disabled")
                     }}</template>

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -104,6 +104,13 @@
               <cv-column>
                 <h4 class="mg-bottom-md">
                   {{ $t("settings_mailboxes.sharedseen") }}
+                  <cv-tooltip
+                    alignment="start"
+                    direction="bottom"
+                    :tip="$t('settings_mailboxes.sharedseen_explanation_tooltips')"
+                    class="info mg-bottom"
+                  >
+                  </cv-tooltip>
                 </h4>
                 <cv-skeleton-text
                   v-if="loading.getMailboxSettings"
@@ -122,15 +129,6 @@
                     "
                     :class="toggle - without - label"
                   >
-                    <template slot="tooltip">
-                      <span
-                        v-html="
-                          $t(
-                            'settings_mailboxes.sharedseen_explanation_tooltips'
-                          )
-                        "
-                      ></span>
-                    </template>
                     <template slot="text-left">{{
                       $t("common.disabled")
                     }}</template>

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -138,7 +138,7 @@
                     :disabled="
                       loading.getMailboxSettings || loading.setMailboxSettings
                     "
-                    :class="toggle - without - label"
+                    class="toggle-without-label"
                   >
                     <template slot="text-left">{{
                       $t("common.disabled")

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -103,25 +103,7 @@
             <cv-row>
               <cv-column>
                 <h4 class="mg-bottom-md">
-                  {{ $t("settings_mailboxes.sharedseen") }}
-                  <cv-interactive-tooltip
-                    alignment="center"
-                    direction="right"
-                    class="info"
-                  >
-                    <template slot="trigger">
-                      <Information16 />
-                    </template>
-                    <template slot="content">
-                      <div>
-                        {{
-                          $t(
-                            "settings_mailboxes.sharedseen_explanation_tooltips"
-                          )
-                        }}
-                      </div>
-                    </template>
-                  </cv-interactive-tooltip>
+                  {{ $t("settings_mailboxes.shared_mailboxes") }}
                 </h4>
                 <cv-skeleton-text
                   v-if="loading.getMailboxSettings"
@@ -132,6 +114,7 @@
                 ></cv-skeleton-text>
                 <cv-form v-else @submit.prevent="setMailboxSettings">
                   <NsToggle
+                    :label="$t('settings_mailboxes.sharedseen')"
                     value="sharedSeenValue"
                     :form-item="true"
                     v-model="sharedseen.enabled"
@@ -140,6 +123,11 @@
                     "
                     class="toggle-without-label"
                   >
+                    <template slot="tooltip">
+                      <span
+                        v-html="$t('settings_mailboxes.sharedseen_explanation_tooltips')"
+                      ></span>
+                    </template>
                     <template slot="text-left">{{
                       $t("common.disabled")
                     }}</template>

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -103,6 +103,51 @@
             <cv-row>
               <cv-column>
                 <h4 class="mg-bottom-md">
+                  {{ $t("settings_mailboxes.sharedseen") }}
+                </h4>
+                <cv-skeleton-text
+                  v-if="loading.getMailboxSettings"
+                  heading
+                  paragraph
+                  :line-count="4"
+                  width="80%"
+                ></cv-skeleton-text>
+                <cv-form v-else @submit.prevent="setMailboxSettings">
+                  <NsToggle
+                    value="sharedSeenValue"
+                    :form-item="true"
+                    v-model="sharedseen.enabled"
+                    :disabled="
+                      loading.getMailboxSettings || loading.setMailboxSettings
+                    "
+                    :class="toggle-without-label"
+                  >
+                    <template slot="text-left">{{
+                      $t("common.disabled")
+                    }}</template>
+                    <template slot="text-right">{{
+                      $t("common.enabled")
+                    }}</template>
+                  </NsToggle>
+                  <NsButton
+                    kind="primary"
+                    :icon="Save20"
+                    :loading="loading.setMailboxSettings"
+                    :disabled="
+                      loading.getMailboxSettings || loading.setMailboxSettings
+                    "
+                    >{{ $t("common.save_settings") }}</NsButton
+                  >
+                </cv-form>
+              </cv-column>
+            </cv-row>
+          </cv-grid>
+        </cv-tile>
+        <cv-tile light>
+          <cv-grid fullWidth class="no-padding">
+            <cv-row>
+              <cv-column>
+                <h4 class="mg-bottom-md">
                   {{ $t("settings_mailboxes.spam") }}
                 </h4>
                 <cv-skeleton-text
@@ -255,6 +300,9 @@ export default {
         enabled: false,
         prefix: "",
       },
+      sharedseen: {
+        enabled: true,
+      },
       loading: {
         getMailboxSettings: false,
         setMailboxSettings: false,
@@ -375,6 +423,7 @@ export default {
       } else {
         this.spamFolder.name = "";
       }
+      this.sharedseen.enabled = settings.sharedseen.enabled;
     },
     validateSetMailboxSettings() {
       this.clearErrors();
@@ -457,6 +506,11 @@ export default {
         spamRetention.value = parseInt(this.spamRetention.value);
       }
 
+      // sharedseen
+      let sharedseen = {
+        enabled: this.sharedseen.enabled,
+      };
+
       const res = await to(
         this.createModuleTaskForApp(this.instanceName, {
           action: taskAction,
@@ -464,6 +518,7 @@ export default {
             quota: quota,
             spam_folder: spamFolder,
             spam_retention: spamRetention,
+            sharedseen: sharedseen,
           },
           extra: {
             title: this.$t("action." + taskAction),

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -104,13 +104,24 @@
               <cv-column>
                 <h4 class="mg-bottom-md">
                   {{ $t("settings_mailboxes.sharedseen") }}
-                  <cv-tooltip
-                    alignment="start"
-                    direction="bottom"
-                    :tip="$t('settings_mailboxes.sharedseen_explanation_tooltips')"
-                    class="info mg-bottom"
+                  <cv-interactive-tooltip
+                    alignment="center"
+                    direction="right"
+                    class="info"
                   >
-                  </cv-tooltip>
+                    <template slot="trigger">
+                      <Information16 />
+                    </template>
+                    <template slot="content">
+                      <div>
+                        {{
+                          $t(
+                            "settings_mailboxes.sharedseen_explanation_tooltips"
+                          )
+                        }}
+                      </div>
+                    </template>
+                  </cv-interactive-tooltip>
                 </h4>
                 <cv-skeleton-text
                   v-if="loading.getMailboxSettings"


### PR DESCRIPTION
Relevant to the trello card https://trello.com/c/Y7HDBVfK/312-mail-p3-migrate-ns7-sharedseen-prop


see the NS7 documentation : https://github.com/NethServer/docs/blob/master/administrator-manual/en/mail.rst#shared-seen-configuration


![image](https://github.com/NethServer/ns8-mail/assets/3164851/40fc82e7-4f48-468b-91b3-3a12aad8613b)

![image](https://github.com/NethServer/ns8-mail/assets/3164851/f5aafd92-f151-4271-84ff-e63edf942d68)
