### PR TITLE
Allow non-existent recipient domain like NS7

### DIFF
--- a/postfix/usr/local/lib/templates/main.cf
+++ b/postfix/usr/local/lib/templates/main.cf
@@ -89,7 +89,6 @@ smtpd_relay_restrictions =
 
 smtpd_recipient_restrictions =
   reject_non_fqdn_recipient,
-  reject_unknown_recipient_domain,
   ${tmpl_verify_recipient_address},
 
 #


### PR DESCRIPTION
When sending an email to multiple recipients and one of them has a non existing domain Webtop does not print the error detail. This can be confusing for the user, so we revert Postfix behavior like NS7, and we generate a bounce message.