### PR TITLE
Enabled flatcurve indexer by default

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -83,7 +83,7 @@ apk add --no-cache rspamd-client
     git clone https://github.com/slusarz/dovecot-fts-flatcurve.git
     cd dovecot-fts-flatcurve/
     ash autogen.sh
-    ./configure --with-dovecot=/usr/lib/dovecot/
+    ./configure --disable-static --with-dovecot=/usr/lib/dovecot/
     make
     make install
     # clean what we installed

--- a/build-images.sh
+++ b/build-images.sh
@@ -74,6 +74,22 @@ apk add --no-cache rspamd-client
     mv -v .post-install /usr/local/bin/dovecot-post-install
     rm -rvf "${tmpdir}"
 )
+(
+    apk add build-base git autoconf automake libtool dovecot-dev  xapian-core-dev  icu-dev
+    mkdir /tmp/build
+    cd /tmp/build
+    git init
+    git config --global --add safe.directory /tmp/build
+    git clone https://github.com/slusarz/dovecot-fts-flatcurve.git
+    cd dovecot-fts-flatcurve/
+    ash autogen.sh
+    ./configure --with-dovecot=/usr/lib/dovecot/
+    make
+    make install
+    # clean what we installed
+    rm -rf /tmp/build
+    apk del build-base git autoconf automake libtool dovecot-dev  xapian-core-dev  icu-dev
+)
 mkdir -p /var/lib/dovecot/dict/uquota
 mkdir -p /var/lib/umail
 sed -i 's/^!/#!/' /etc/dovecot/conf.d/10-auth.conf

--- a/build-images.sh
+++ b/build-images.sh
@@ -61,7 +61,7 @@ set -e
 addgroup -g 101 -S vmail
 adduser -u 100 -G vmail -h /var/lib/vmail -S vmail
 chmod -c 700 /var/lib/vmail
-apk add --no-cache dovecot dovecot-ldap dovecot-pigeonhole-plugin dovecot-pop3d dovecot-lmtpd openldap-clients gettext
+apk add --no-cache dovecot dovecot-ldap dovecot-pigeonhole-plugin dovecot-pop3d dovecot-lmtpd openldap-clients gettext xapian-core
 apk add --no-cache rspamd-client
 (
     # Remove the self-signed certificate
@@ -75,7 +75,7 @@ apk add --no-cache rspamd-client
     rm -rvf "${tmpdir}"
 )
 (
-    apk add --no-cache build-base git autoconf automake libtool dovecot-dev xapian-core xapian-core-dev  icu-dev
+    apk add --no-cache build-base git autoconf automake libtool dovecot-dev xapian-core-dev  icu-dev
     mkdir /tmp/build
     cd /tmp/build
     git clone https://github.com/slusarz/dovecot-fts-flatcurve.git

--- a/build-images.sh
+++ b/build-images.sh
@@ -61,7 +61,7 @@ set -e
 addgroup -g 101 -S vmail
 adduser -u 100 -G vmail -h /var/lib/vmail -S vmail
 chmod -c 700 /var/lib/vmail
-apk add --no-cache dovecot dovecot-ldap dovecot-pigeonhole-plugin dovecot-pop3d dovecot-lmtpd openldap-clients gettext xapian-core
+apk add --no-cache dovecot dovecot-ldap dovecot-pigeonhole-plugin dovecot-pop3d dovecot-lmtpd openldap-clients gettext xapian-core poppler-utils catdoc
 apk add --no-cache rspamd-client
 (
     # Remove the self-signed certificate

--- a/build-images.sh
+++ b/build-images.sh
@@ -75,7 +75,7 @@ apk add --no-cache rspamd-client
     rm -rvf "${tmpdir}"
 )
 (
-    apk add --no-cache build-base git autoconf automake libtool dovecot-dev  xapian-core-dev  icu-dev
+    apk add --no-cache build-base git autoconf automake libtool dovecot-dev xapian-core xapian-core-dev  icu-dev
     mkdir /tmp/build
     cd /tmp/build
     git init
@@ -88,7 +88,7 @@ apk add --no-cache rspamd-client
     make install
     # clean what we installed
     rm -rf /tmp/build
-    apk del build-base git autoconf automake libtool dovecot-dev  xapian-core-dev  icu-dev
+    apk del build-base git autoconf automake libtool xapian-core-dev dovecot-dev icu-dev
 )
 mkdir -p /var/lib/dovecot/dict/uquota
 mkdir -p /var/lib/umail

--- a/build-images.sh
+++ b/build-images.sh
@@ -78,8 +78,6 @@ apk add --no-cache rspamd-client
     apk add --no-cache build-base git autoconf automake libtool dovecot-dev xapian-core xapian-core-dev  icu-dev
     mkdir /tmp/build
     cd /tmp/build
-    git init
-    git config --global --add safe.directory /tmp/build
     git clone https://github.com/slusarz/dovecot-fts-flatcurve.git
     cd dovecot-fts-flatcurve/
     ash autogen.sh

--- a/build-images.sh
+++ b/build-images.sh
@@ -75,7 +75,7 @@ apk add --no-cache rspamd-client
     rm -rvf "${tmpdir}"
 )
 (
-    apk add build-base git autoconf automake libtool dovecot-dev  xapian-core-dev  icu-dev
+    apk add --no-cache build-base git autoconf automake libtool dovecot-dev  xapian-core-dev  icu-dev
     mkdir /tmp/build
     cd /tmp/build
     git init

--- a/build-images.sh
+++ b/build-images.sh
@@ -61,7 +61,7 @@ set -e
 addgroup -g 101 -S vmail
 adduser -u 100 -G vmail -h /var/lib/vmail -S vmail
 chmod -c 700 /var/lib/vmail
-apk add --no-cache dovecot dovecot-ldap dovecot-pigeonhole-plugin dovecot-pop3d dovecot-lmtpd openldap-clients gettext xapian-core poppler-utils catdoc
+apk add --no-cache dovecot dovecot-ldap dovecot-pigeonhole-plugin dovecot-pop3d dovecot-lmtpd openldap-clients gettext xapian-core poppler-utils
 apk add --no-cache rspamd-client
 (
     # Remove the self-signed certificate

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -29,7 +29,7 @@ stats_http_port=${DOVECOT_METRICS_PORT:?}
 tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
 tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
 tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
-tmpl_mail_plugins="acl listescape notify mail_log"
+tmpl_mail_plugins="acl listescape notify mail_log fts fts_flatcurve"
 tmpl_mail_max_userip_connections="${DOVECOT_MAX_USERIP_CONNECTIONS:-20}"
 # Note: value "0" means "unlimited default quota"; value "" (empty string)
 # means "quota plugin disabled".

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -190,8 +190,16 @@ plugin {
   # ja needs Requires separate Kuromoji license
   fts_languages = da de en es fi fr it nl no pt ro ru sv tr
   fts_tokenizers = generic email-address
+  fts_decoder = decode2text
 }
 
+service decode2text {
+  executable = script /usr/libexec/dovecot/decode2text.sh
+  user = vmail
+  unix_listener decode2text {
+    mode = 0666
+  }
+}
 #
 # 90-postlogin
 #

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -191,6 +191,8 @@ plugin {
   fts_languages = da de en es fi fr it nl no pt ro ru sv tr
   fts_tokenizers = generic email-address
   fts_decoder = decode2text
+  fts_filters = lowercase normalizer-icu snowball stopwords
+  fts_filters_en = lowercase snowball english-possessive stopwords
 }
 
 service decode2text {

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -172,18 +172,24 @@ protocol lmtp {
 # 90-acls
 #
 protocol imap {
-  mail_plugins = ${S}mail_plugins imap_acl imap_sieve fts fts_flatcurve
+  mail_plugins = ${S}mail_plugins imap_acl imap_sieve
 }
 
+plugin {
+  acl = vfile
+  acl_user = %u
+  acl_shared_dict = file:/var/lib/vmail/shared-mailboxes.db
+}
+
+#
+# FTS (Full Text Search)
+#
 plugin {
   fts = flatcurve
   fts_autoindex = yes
   # ja needs Requires separate Kuromoji license
   fts_languages = da de en es fi fr it nl no pt ro ru sv tr
   fts_tokenizers = generic email-address
-  acl = vfile
-  acl_user = %u
-  acl_shared_dict = file:/var/lib/vmail/shared-mailboxes.db
 }
 
 #

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -191,8 +191,8 @@ plugin {
   fts_languages = da de en es fi fr it nl no pt ro ru sv tr
   fts_tokenizers = generic email-address
   fts_decoder = decode2text
-  fts_filters = lowercase normalizer-icu snowball stopwords
-  fts_filters_en = lowercase snowball english-possessive stopwords
+  fts_filters = lowercase normalizer-icu stopwords
+  fts_filters_en = lowercase english-possessive stopwords
 }
 
 service decode2text {

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -172,10 +172,15 @@ protocol lmtp {
 # 90-acls
 #
 protocol imap {
-  mail_plugins = ${S}mail_plugins imap_acl imap_sieve
+  mail_plugins = ${S}mail_plugins imap_acl imap_sieve fts fts_flatcurve
 }
 
 plugin {
+  fts = flatcurve
+  fts_autoindex = yes
+  # ja needs Requires separate Kuromoji license
+  fts_languages = da de en es fi fr it nl no pt ro ru sv tr
+  fts_tokenizers = generic email-address
   acl = vfile
   acl_user = %u
   acl_shared_dict = file:/var/lib/vmail/shared-mailboxes.db


### PR DESCRIPTION
build from https://gist.github.com/stephdl/bfcc1b26e7a8b61f41f99fd163f329ab

doc fts dovecot:
https://doc.dovecot.org/settings/plugin/fts-plugin/
https://doc.dovecot.org/configuration_manual/fts/#fts
https://doc.dovecot.org/3.0/configuration_manual/fts/flatcurve/

doc flatcurve:
https://slusarz.github.io/dovecot-fts-flatcurve/configuration.html
https://slusarz.github.io/dovecot-fts-flatcurve/doveadm.html


method to test
- roundcubemail with search box
- telnet
```
[root@R2 ~]# telnet localhost imap
Trying ::1...
Connected to localhost.
Escape character is '^]'.
* OK [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+ STARTTLS AUTH=PLAIN AUTH=LOGIN] Dovecot ready.
1 login administrator Nethesis,1234
1 OK [CAPABILITY IMAP4rev1 SASL-IR LOGIN-REFERRALS ID ENABLE IDLE SORT SORT=DISPLAY THREAD=REFERENCES THREAD=REFS THREAD=ORDEREDSUBJECT MULTIAPPEND URL-PARTIAL CATENATE UNSELECT CHILDREN NAMESPACE UIDPLUS LIST-EXTENDED I18NLEVEL=1 CONDSTORE QRESYNC ESEARCH ESORT SEARCHRES WITHIN CONTEXT=SEARCH LIST-STATUS BINARY MOVE SNIPPET=FUZZY PREVIEW=FUZZY PREVIEW STATUS=SIZE SAVEDATE LITERAL+ NOTIFY SPECIAL-USE QUOTA ACL RIGHTS=texk] Logged in
2 select inbox
* FLAGS (\Answered \Flagged \Deleted \Seen \Draft)
* OK [PERMANENTFLAGS (\Answered \Flagged \Deleted \Seen \Draft \*)] Flags permitted.
* 1 EXISTS
* 0 RECENT
* OK [UNSEEN 1] First unseen.
* OK [UIDVALIDITY 1693383298] UIDs valid
* OK [UIDNEXT 2] Predicted next UID
* OK [HIGHESTMODSEQ 2] Highest
2 OK [READ-WRITE] Select completed (0.001 + 0.000 + 0.001 secs).
3 search text "toto"           
* SEARCH 1
3 OK Search completed (0.266 + 0.000 + 0.002 secs).
4 search text 'titi'
* SEARCH
4 OK Search completed (0.256 + 0.000 + 0.001 secs).
```
