### PR TITLE
Use rspamd junk tag X-Spam

### DIFF
--- a/dovecot/usr/local/bin/spam-expunge
+++ b/dovecot/usr/local/bin/spam-expunge
@@ -32,6 +32,6 @@ for muser in $(doveadm user \*); do
     doveadm expunge -u "${muser}" \
         SENTBEFORE "${spam_retention}d" \
         MAILBOX "${DOVECOT_SPAM_FOLDER:-INBOX}" \
-        HEADER X-Spam-Flag YES 2>/dev/null \
+        HEADER X-Spam YES 2>/dev/null \
         || :
 done


### PR DESCRIPTION
ns8-mail uses now the conventional tag of rspamd and no more the junk tag of spammassin

```
- X-Spam-Flag
+ X-Spam
```