### PR TITLE
Update org.nethserver.authorizations label and bind new domain

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -44,7 +44,7 @@ buildah config --entrypoint=/ \
         rspamd \
         clamav \
     )" \
-    --label="org.nethserver.authorizations=node:fwadm traefik@node:fulladm" \
+    --label="org.nethserver.authorizations=node:fwadm traefik@node:fulladm cluster:accountconsumer" \
     "${container}"
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -71,3 +71,5 @@ if not os.getenv('POSTFIX_TRUSTED_NETWORK'):
     agent.set_env('POSTFIX_TRUSTED_NETWORK', cluster_network)
 agent.set_env('POSTFIX_HOSTNAME', hostname)
 agent.set_env('POSTFIX_ORIGIN', udomname)
+# Bind the new domain, overriding previous values (unbind)
+agent.bind_user_domains([udomname])

--- a/imageroot/update-module.d/90bind_user_domain
+++ b/imageroot/update-module.d/90bind_user_domain
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+import sys
+import json
+
+if not hasattr(agent, 'get_bound_domain_list'):
+    sys.exit(0) # core version too old, skip and try on next update
+
+rdb = agent.redis_connect(use_replica=True)
+user_ldap_domain = rdb.hget(f"module/{os.getenv('MODULE_ID')}/srv/tcp/imap", "user_domain")
+if user_ldap_domain and not agent.get_bound_domain_list(rdb):
+    agent.bind_user_domains([user_ldap_domain])


### PR DESCRIPTION
This pull request updates the org.nethserver.authorizations label in the build-images.sh script and adds the binding of a new domain in the discover-services script. The org.nethserver.authorizations label is updated to include the cluster:accountconsumer authorization. Additionally, the new domain is bound, overriding previous values.

NethServer/dev#6814