### PR TITLE
Remove unnecessary code for setting master users

### DIFF
--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -19,6 +19,7 @@ for evar in [
         "RSPAMD_greylist_enabled",
         "DOVECOT_TRUSTED_NETWORKS",
         "POSTFIX_TRUSTED_NETWORK",
+        "DOVECOT_MASTER_USERS"
     ]:
     if evar in original_environment:
         agent.set_env(evar, original_environment[evar])

--- a/imageroot/actions/restore-module/70configure_module
+++ b/imageroot/actions/restore-module/70configure_module
@@ -54,10 +54,3 @@ filter_retval =  agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='set-fi
     # - antispam state and greylist switches state are in the environment from 06copyenv
 })
 agent.assert_exp(filter_retval['exit_code'] == 0, "The set-filter-configuration subtask failed!")
-
-masters_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='set-master-users', data={
-    "master_users": list(filter(None, renv.get("DOVECOT_MASTER_USERS", "").split(",")))
-})
-agent.assert_exp(masters_retval['exit_code'] == 0, "The set-master-users subtask failed!")
-
-


### PR DESCRIPTION
Add DOVECOT_MASTER_USERS to environment variables

This pull request removes unnecessary code for setting master users and adds the DOVECOT_MASTER_USERS environment variable.