### PR TITLE
Update hostname format in validator-definitions.json

### DIFF
--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -27,7 +27,7 @@
             "title": "Initial mail domain",
             "description": "Create the first mail domain with default values. Ignored if the module was already configured.",
             "minLength": 1,
-            "format": "idn-hostname",
+            "format": "hostname",
             "pattern": "\\."
         },
         "hostname": {
@@ -35,7 +35,8 @@
             "title": "Mail host name",
             "description": "Host name used as SMTP/HELO and for the TLS certificate",
             "minLength": 1,
-            "format": "idn-hostname"
+            "format": "hostname",
+            "pattern": "\\."
         }
     }
 }

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -124,7 +124,7 @@
                 "domain": {
                     "title": "Mail domain",
                     "description": "The standard-compliant domain name",
-                    "format": "idn-hostname",
+                    "format": "hostname",
                     "pattern": "\\."
                 },
                 "addusers": {

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -303,7 +303,7 @@
                 "domain": {
                     "type": "string",
                     "title": "Address domain part",
-                    "format": "idn-hostname",
+                    "format": "hostname",
                     "pattern": "\\."
                 },
                 "local": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -118,7 +118,10 @@
     "no_domain_configured": "No user domain configured",
     "no_domain_configured_description": "Please configure a user domain first",
     "go_to_domains_and_users": "Go to Domains and users",
-    "mail_domain_pattern": "Invalid domain"
+    "hostname_pattern": "Must be a valid fully qualified domain name",
+    "hostname_format": "Must be a valid fully qualified domain name",
+    "mail_domain_pattern": "Must be a valid fully qualified domain name",
+    "mail_domain_format": "Must be a valid fully qualified domain name"
   },
   "domains": {
     "title": "Domains",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -157,7 +157,9 @@
     "dkim_txt_record_raw_procedure": "Paste the full TXT record in raw form",
     "domain_pattern": "Must be a valid fully qualified domain name",
     "domain_format": "Must be a valid fully qualified domain name",
-    "mail_domain_already_exists": "Domain already exists"
+    "mail_domain_already_exists": "Domain already exists",
+    "catchall_mailbox_not_found": "Catchall mailbox not found",
+    "domain_not_found": "Domain not found"
   },
   "addresses": {
     "title": "Addresses",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -141,7 +141,6 @@
     "delete_domain": "Delete domain",
     "delete_domain_confirm": "Delete domain <strong>{name}</strong>?",
     "delete_domain_explanation": "All associated email addresses will be deleted as well. However, all email messages received and sent by this domain will be preserved.",
-    "domain_pattern": "Invalid domain",
     "required_if_accept_unknown_recipients": "Required if \"Accept unknown recipients\" is enabled",
     "required_if_copy_inbound_messages": "Required if \"Copy inbound messages\" is enabled",
     "bccaddr_format": "Invalid email format",
@@ -155,7 +154,10 @@
     "configure_dkim_for_domain": "Configure DKIM for {domain}",
     "dkim_txt_record_description": "Create the TXT record required by DKIM at your <strong>{domain}</strong> DNS service provider by choosing <strong>one of the following procedures</strong>",
     "dkim_txt_record_key_procedure": "Set <strong>default._domainkey</strong> as record key and paste the record data",
-    "dkim_txt_record_raw_procedure": "Paste the full TXT record in raw form"
+    "dkim_txt_record_raw_procedure": "Paste the full TXT record in raw form",
+    "domain_pattern": "Must be a valid fully qualified domain name",
+    "domain_format": "Must be a valid fully qualified domain name",
+    "mail_domain_already_exists": "Domain already exists"
   },
   "addresses": {
     "title": "Addresses",


### PR DESCRIPTION
This pull request updates the hostname format in the validator-definitions.json file to use a valid fully qualified domain name format. This ensures that the hostname input field accepts only valid FQDN. The changes are made in the validate-input.json, validator-definitions.json, translation.json, FirstConfigurationModal.vue, and CreateOrEditDomainModal.vue files.

![image](https://github.com/NethServer/ns8-mail/assets/3164851/0736988c-e65f-4db8-8636-c636379deac8)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/e519adb0-19e8-464d-b10f-70ad7d108a97)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/2b83a0f5-6970-49f2-a26b-9ac8107e09dd)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/b8be5624-6393-438c-83ff-c532690dedc5)



I found this error relevant to a missing string in mail server

![image](https://github.com/NethServer/ns8-mail/assets/3164851/01bb6cbf-9923-4f78-8cba-40d5cf4c84ca)

fix: 

![image](https://github.com/NethServer/ns8-mail/assets/3164851/183eb5f7-0e95-443b-bd13-49d066cf7146)
