### PR TITLE
Add symlink for traefik module in clone-module

### DIFF
--- a/imageroot/actions/clone-module/90traefik
+++ b/imageroot/actions/clone-module/90traefik
@@ -1,0 +1,1 @@
+../configure-module/90traefik


### PR DESCRIPTION
This pull request adds a symlink for the traefik module in the clone-module directory. This will allow to create the traefik route when the module is moved

https://github.com/NethServer/dev/issues/6875