### PR TITLE
Add maximal_queue_lifetime configuration

### DIFF
--- a/imageroot/actions/get-queue-settings/10get_queue_settings
+++ b/imageroot/actions/get-queue-settings/10get_queue_settings
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import mail
+import agent
+import os
+
+postfix_maximal_queue_lifetime = os.getenv("POSTFIX_MAXIMAL_QUEUE_LIFETIME", '120')
+
+json.dump({"maximal_queue_lifetime": postfix_maximal_queue_lifetime,}, fp=sys.stdout)

--- a/imageroot/actions/get-queue-settings/validate-output.json
+++ b/imageroot/actions/get-queue-settings/validate-output.json
@@ -16,7 +16,7 @@
     "properties": {
         "maximal_queue_lifetime": {
             "type": "string",
-            "title": "maximal_queue_lifetime",
+            "title": "Maximal queue lifetime",
             "description": "Maximum hours a message can stay in the queue before being returned to the sender"
         }
     }

--- a/imageroot/actions/get-queue-settings/validate-output.json
+++ b/imageroot/actions/get-queue-settings/validate-output.json
@@ -1,0 +1,23 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "get-mailbox-settings input",
+    "$id": "http://schema.nethserver.org/mail/get-mailbox-settings.json",
+    "description": "Get mailbox default configuration values",
+    "examples": [
+        {
+            "maximal_queue_lifetime": 30
+        }
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "maximal_queue_lifetime"
+    ],
+    "properties": {
+        "maximal_queue_lifetime": {
+            "type": "string",
+            "title": "maximal_queue_lifetime",
+            "description": "Maximum hours a message can stay in the queue before being returned to the sender"
+        }
+    }
+}

--- a/imageroot/actions/set-queue-settings/10set_mailbox_settings
+++ b/imageroot/actions/set-queue-settings/10set_mailbox_settings
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+
+request = json.load(sys.stdin)
+
+maximal_queue_lifetime = int(request['maximal_queue_lifetime'])
+agent.set_env("POSTFIX_MAXIMAL_QUEUE_LIFETIME", maximal_queue_lifetime)
+

--- a/imageroot/actions/set-queue-settings/20reload_postfix
+++ b/imageroot/actions/set-queue-settings/20reload_postfix
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+
+systemctl --user reload postfix.service

--- a/imageroot/actions/set-queue-settings/validate-input.json
+++ b/imageroot/actions/set-queue-settings/validate-input.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "set-mailbox-settings input",
+    "$id": "http://schema.nethserver.org/mail/set-queue-settings.json",
+    "description": "Set queue default configuration values",
+    "examples": [
+        {
+            "maximal_queue_lifetime": 5
+        }
+    ],
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "maximal_queue_lifetime": {
+            "type": "integer",
+            "title": "maximal_queue_lifetime",
+            "minimum": 1,
+            "maximum": 200,
+            "description": "Maximum hours a message can stay in the queue before being returned to the sender"
+        }
+    }
+}

--- a/imageroot/actions/set-queue-settings/validate-input.json
+++ b/imageroot/actions/set-queue-settings/validate-input.json
@@ -13,7 +13,7 @@
     "properties": {
         "maximal_queue_lifetime": {
             "type": "integer",
-            "title": "maximal_queue_lifetime",
+            "title": "Maximal queue lifetime",
             "minimum": 1,
             "maximum": 200,
             "description": "Maximum hours a message can stay in the queue before being returned to the sender"

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -38,6 +38,7 @@ Standard public TCP ports
 - `POSTFIX_LDAP_SCHEMA`, eg `rfc2307`
 - `POSTFIX_LDAP_BASE`, eg `dc=directory,dc=nh`
 - `POSTFIX_MILTERS`, value for Postfix [smtpd_milters](http://www.postfix.org/postconf.5.html#smtpd_milters)
+- `POSTFIX_MAXIMAL_QUEUE_LIFETIME`, value for the maximum amount of hours that a message is allowed to stay in a queue
 
 ## Volumes
 

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -38,7 +38,7 @@ Standard public TCP ports
 - `POSTFIX_LDAP_SCHEMA`, eg `rfc2307`
 - `POSTFIX_LDAP_BASE`, eg `dc=directory,dc=nh`
 - `POSTFIX_MILTERS`, value for Postfix [smtpd_milters](http://www.postfix.org/postconf.5.html#smtpd_milters)
-- `POSTFIX_MAXIMAL_QUEUE_LIFETIME`, value for the maximum amount of hours that a message is allowed to stay in a queue
+- `POSTFIX_MAXIMAL_QUEUE_LIFETIME`, value for the maximum amount of hours that a message is allowed to stay in a queue (5 days is assumed if value is empty)
 
 ## Volumes
 

--- a/postfix/usr/local/bin/reload-config
+++ b/postfix/usr/local/bin/reload-config
@@ -74,6 +74,7 @@ tmpl_ldap_bind_pw="${POSTFIX_LDAP_PASS}"
 tmpl_ldap_host="${POSTFIX_LDAP_HOST}"
 tmpl_ldap_port="${POSTFIX_LDAP_PORT}"
 tmpl_ldap_base="${POSTFIX_LDAP_BASE}"
+tmpl_maximal_queue_lifetime="${POSTFIX_MAXIMAL_QUEUE_LIFETIME:-120}"
 set +a
 
 envsubst >/etc/postfix/main.cf <"${TEMPLATES_DIR:?}/main.cf"

--- a/postfix/usr/local/lib/templates/main.cf
+++ b/postfix/usr/local/lib/templates/main.cf
@@ -22,7 +22,7 @@ sendmail_path = /usr/sbin/sendmail
 setgid_group = postdrop
 shlib_directory = /usr/lib/postfix
 unknown_local_recipient_reject_code = 550
-
+maximal_queue_lifetime = ${tmpl_maximal_queue_lifetime}h
 #
 # Debug config flags
 #

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -388,6 +388,6 @@
     "cancel": "Cancel",
     "queue_tooltip": "These are the messages that are waiting to be relayed in the SMTP mail queue. In normal conditions, this queue should be empty or contain just a few messages.",
     "delete_email_confirm": "Delete email <strong>{name}</strong>?",
-    "maximal_queue_lifetime_info": "The maximal queue lifetime is set to {maximal_queue_lifetime} hours."
+    "maximal_queue_lifetime_info": "The maximal queue lifetime is set to {maximal_queue_lifetime} hour.|The maximal queue lifetime is set to {maximal_queue_lifetime} hours."
   }
 }

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -92,7 +92,7 @@
     "get-filter-configuration": "Get filter configuration",
     "set-filter-configuration": "Set filter configuration",
     "report-queue-status": "List deferred messages in postfix queue",
-    "flush-postfix-queue": "Flush postfix queue",
+    "flush-postfix-queue": "Flush Postfix queue",
     "get-queue-settings": "Get queue settings",
     "set-queue-settings": "Set queue settings"
   },
@@ -346,11 +346,11 @@
   "settings_queue": {
     "title": "Queue settings",
     "maximal_queue_lifetime": "Maximal queue lifetime",
-    "must_be_inferior_or_equal_to_200": "Must be inferior or equal to 200",
-    "must_be_superior_or_equal_to_1": "Must be superior or equal to 1",
+    "must_be_inferior_or_equal_to_200": "Must be less than or equal to 200",
+    "must_be_superior_or_equal_to_1": "Must be greater than or equal to 1",
     "hours": "hours",
     "maximal_queue_lifetime_tooltip": "Consider a message as not deliverable if it remains in the queue for the maximum queue lifetime.",
-    "maximal_queue_lifetime_helper": "Time interval expressed in hours (default value is 120 hours)."
+    "maximal_queue_lifetime_helper": "Time interval expressed in hours"
   },
   "settings_general": {
     "title": "General settings",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -346,6 +346,8 @@
   "settings_queue": {
     "title": "Queue settings",
     "maximal_queue_lifetime": "Maximal queue lifetime",
+    "must_be_inferior_or_equal_to_200": "Must be inferior or equal to 200",
+    "must_be_superior_or_equal_to_1": "Must be superior or equal to 1",
     "hours": "hours",
     "maximal_queue_lifetime_tooltip": "Set the duration, in hours, after which undelivered messages should be returned to the sender.",
     "maximal_queue_lifetime_helper": "Timespan expressed in hours"

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -349,8 +349,8 @@
     "must_be_inferior_or_equal_to_200": "Must be inferior or equal to 200",
     "must_be_superior_or_equal_to_1": "Must be superior or equal to 1",
     "hours": "hours",
-    "maximal_queue_lifetime_tooltip": "Set the duration, in hours, after which undelivered messages should be returned to the sender.",
-    "maximal_queue_lifetime_helper": "Timespan expressed in hours"
+    "maximal_queue_lifetime_tooltip": "Consider a message as not deliverable if it remains in the queue for the maximum queue lifetime.",
+    "maximal_queue_lifetime_helper": "Time interval expressed in hours (default value is 120 hours)."
   },
   "settings_general": {
     "title": "General settings",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -346,9 +346,9 @@
   "settings_queue": {
     "title": "Queue settings",
     "maximal_queue_lifetime": "Maximal queue lifetime",
-    "hours": "Hours",
-    "maximal_queue_lifetime_tooltip": "Consider a message as undeliverable, when the time in the queue has reached the maximal queue lifetime limit in hours.",
-    "maximal_queue_lifetime_helper": "Timespan expressed in hours(default 120 hours)."
+    "hours": "hours",
+    "maximal_queue_lifetime_tooltip": "Set the duration, in hours, after which undelivered messages should be returned to the sender.",
+    "maximal_queue_lifetime_helper": "Timespan expressed in hours"
   },
   "settings_general": {
     "title": "General settings",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -92,7 +92,9 @@
     "get-filter-configuration": "Get filter configuration",
     "set-filter-configuration": "Set filter configuration",
     "report-queue-status": "List deferred messages in postfix queue",
-    "flush-postfix-queue": "Flush postfix queue"
+    "flush-postfix-queue": "Flush postfix queue",
+    "get-queue-settings": "Get queue settings",
+    "set-queue-settings": "Set queue settings"
   },
   "error": {
     "error": "Error",
@@ -340,6 +342,13 @@
     "page_description": "Master users are privileged users that can impersonate another user while interacting with their mailbox",
     "master_users": "Master users",
     "master_users_placeholder": "Choose master users"
+  },
+  "settings_queue": {
+    "title": "Queue settings",
+    "maximal_queue_lifetime": "Maximal queue lifetime",
+    "hours": "Hours",
+    "maximal_queue_lifetime_tooltip": "Consider a message as undeliverable, when the time in the queue has reached the maximal queue lifetime limit in hours.",
+    "maximal_queue_lifetime_helper": "Timespan expressed in hours(default 120 hours)."
   },
   "settings_general": {
     "title": "General settings",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -388,6 +388,6 @@
     "cancel": "Cancel",
     "queue_tooltip": "These are the messages that are waiting to be relayed in the SMTP mail queue. In normal conditions, this queue should be empty or contain just a few messages.",
     "delete_email_confirm": "Delete email <strong>{name}</strong>?",
-    "maximal_queue_lifetime_info": "The maximal queue lifetime is set to {maximal_queue_lifetime} hour.|The maximal queue lifetime is set to {maximal_queue_lifetime} hours."
+    "maximal_queue_lifetime_info": "The maximal queue lifetime is set to {maximal_queue_lifetime} hour. | The maximal queue lifetime is set to {maximal_queue_lifetime} hours."
   }
 }

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -385,6 +385,7 @@
     "confirm_delete_queued_message": "The email message will be deleted, are you sure?",
     "cancel": "Cancel",
     "queue_tooltip": "These are the messages that are waiting to be relayed in the SMTP mail queue. In normal conditions, this queue should be empty or contain just a few messages.",
-    "delete_email_confirm": "Delete email <strong>{name}</strong>?"
+    "delete_email_confirm": "Delete email <strong>{name}</strong>?",
+    "maximal_queue_lifetime_info": "The maximal queue lifetime is set to {maximal_queue_lifetime} hours."
   }
 }

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -86,6 +86,14 @@ const routes = [
       ),
   },
   {
+    path: "/settingsQueue",
+    name: "SettingsQueue",
+    component: () =>
+      import(
+        /* webpackChunkName: "settings-master-users" */ "../views/settings/SettingsQueue.vue"
+      ),
+  },
+  {
     path: "/about",
     name: "About",
     // route level code-splitting

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -90,7 +90,7 @@ const routes = [
     name: "SettingsQueue",
     component: () =>
       import(
-        /* webpackChunkName: "settings-master-users" */ "../views/settings/SettingsQueue.vue"
+        /* webpackChunkName: "settings-queue" */ "../views/settings/SettingsQueue.vue"
       ),
   },
   {

--- a/ui/src/views/DeferredQueue.vue
+++ b/ui/src/views/DeferredQueue.vue
@@ -96,7 +96,7 @@
             <NsSvg :svg="InformationFilled16" class="icon ns-info" />
             <span>
               {{
-                $t("queue.maximal_queue_lifetime_info", {
+                $tc("queue.maximal_queue_lifetime_info", parseInt(maximal_queue_lifetime), {
                   maximal_queue_lifetime: maximal_queue_lifetime,
                 })
               }}

--- a/ui/src/views/DeferredQueue.vue
+++ b/ui/src/views/DeferredQueue.vue
@@ -89,10 +89,17 @@
       </cv-row>
       <cv-row>
         <cv-column>
-          <div class="mg-top-sm mg-bottom-lg">
+          <div
+            v-if="!loading.getQueueSettings && !loading.listDeferredQueue"
+            class="mg-top-sm mg-bottom-lg"
+          >
             <NsSvg :svg="InformationFilled16" class="icon ns-info" />
             <span>
-              {{ $t("queue.maximal_queue_lifetime_info", {maximal_queue_lifetime: maximal_queue_lifetime}) }}
+              {{
+                $t("queue.maximal_queue_lifetime_info", {
+                  maximal_queue_lifetime: maximal_queue_lifetime,
+                })
+              }}
             </span>
           </div>
         </cv-column>

--- a/ui/src/views/DeferredQueue.vue
+++ b/ui/src/views/DeferredQueue.vue
@@ -92,9 +92,8 @@
           <div class="mg-top-sm mg-bottom-lg">
             <NsSvg :svg="InformationFilled16" class="icon ns-info" />
             <span>
-              {{ $t("settings_queue.maximal_queue_lifetime") }}
+              {{ $t("queue.maximal_queue_lifetime_info", {maximal_queue_lifetime: maximal_queue_lifetime}) }}
             </span>
-            {{ maximal_queue_lifetime + " " + $t("settings_queue.hours") }}
           </div>
         </cv-column>
       </cv-row>

--- a/ui/src/views/DeferredQueue.vue
+++ b/ui/src/views/DeferredQueue.vue
@@ -21,6 +21,18 @@
             </cv-interactive-tooltip>
           </h2>
         </cv-column>
+        <cv-column :md="4" :xlg="6">
+          <div class="page-toolbar">
+            <NsButton
+              kind="tertiary"
+              size="field"
+              :icon="Settings20"
+              @click="goToQueueSettings()"
+              class="page-toolbar-item"
+              >{{ $t("mailboxes.settings") }}</NsButton
+            >
+          </div>
+        </cv-column>
       </cv-row>
       <cv-row>
         <cv-column>
@@ -329,6 +341,9 @@ export default {
     this.listDeferredQueue();
   },
   methods: {
+    goToQueueSettings() {
+      this.goToAppPage(this.instanceName, "settingsQueue");
+    },
     showQueueDetailModal(queue) {
       this.currentMessage = queue;
       this.isShownQueueDetailModal = true;

--- a/ui/src/views/settings/Settings.vue
+++ b/ui/src/views/settings/Settings.vue
@@ -40,6 +40,16 @@
           <h6>{{ $t("settings_master_users.title") }}</h6>
         </NsTile>
       </cv-column>
+      <cv-column :md="4" :xlg="4">
+        <NsTile
+          :light="true"
+          kind="clickable"
+          @click="goToAppPage(instanceName, 'settingsQueue')"
+          :icon="MailAll32"
+        >
+          <h6>{{ $t("settings_queue.title") }}</h6>
+        </NsTile>
+      </cv-column>
     </cv-row>
   </cv-grid>
 </template>

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -85,7 +85,7 @@
                     @byteUnit="quota.byteUnit = $event"
                   />
                   <NsButton
-                    kind="primary"
+                    kind="secondary"
                     :icon="Save20"
                     :loading="loading.setMailboxSettings"
                     :disabled="
@@ -136,7 +136,7 @@
                     }}</template>
                   </NsToggle>
                   <NsButton
-                    kind="primary"
+                    kind="secondary"
                     :icon="Save20"
                     :loading="loading.setMailboxSettings"
                     :disabled="
@@ -242,7 +242,7 @@
                     ref="spamSubjectPrefix"
                   />
                   <NsButton
-                    kind="primary"
+                    kind="secondary"
                     :icon="Save20"
                     :loading="loading.setMailboxSettings"
                     :disabled="

--- a/ui/src/views/settings/SettingsQueue.vue
+++ b/ui/src/views/settings/SettingsQueue.vue
@@ -314,8 +314,4 @@ export default {
 .cv-form .bx--form-item {
   margin-bottom: $spacing-07;
 }
-
-.toggle-dependent {
-  margin-bottom: $spacing-07;
-}
 </style>

--- a/ui/src/views/settings/SettingsQueue.vue
+++ b/ui/src/views/settings/SettingsQueue.vue
@@ -1,0 +1,321 @@
+<!--
+  Copyright (C) 2023 Nethesis S.r.l.
+  SPDX-License-Identifier: GPL-3.0-or-later
+-->
+<template>
+  <cv-grid fullWidth>
+    <cv-row>
+      <cv-column>
+        <cv-breadcrumb
+          aria-label="breadcrumb"
+          :no-trailing-slash="true"
+          class="breadcrumb"
+        >
+          <cv-breadcrumb-item>
+            <cv-link @click="goToSettings">{{ $t("settings.title") }}</cv-link>
+          </cv-breadcrumb-item>
+          <cv-breadcrumb-item>
+            <span>{{ $t("settings_queue.title") }}</span>
+          </cv-breadcrumb-item>
+        </cv-breadcrumb>
+      </cv-column>
+    </cv-row>
+    <cv-row>
+      <cv-column class="page-title">
+        <h2>{{ $t("settings_queue.title") }}</h2>
+      </cv-column>
+    </cv-row>
+    <cv-row v-if="error.setQueueSettings">
+      <cv-column>
+        <NsInlineNotification
+          kind="error"
+          :title="$t('action.set-mailbox-settings')"
+          :description="error.setQueueSettings"
+          :showCloseButton="false"
+        />
+      </cv-column>
+    </cv-row>
+    <cv-row v-if="error.getQueueSettings">
+      <cv-column>
+        <NsInlineNotification
+          kind="error"
+          :title="$t('action.get-mailbox-settings')"
+          :description="error.getQueueSettings"
+          :showCloseButton="false"
+        />
+      </cv-column>
+    </cv-row>
+    <cv-row v-else>
+      <cv-column>
+        <cv-tile light>
+          <cv-grid fullWidth class="no-padding">
+            <cv-row>
+              <cv-column>
+                <cv-skeleton-text
+                  v-if="loading.getQueueSettings"
+                  heading
+                  paragraph
+                  :line-count="4"
+                  width="80%"
+                ></cv-skeleton-text>
+                <cv-form v-else @submit.prevent="setQueueSettings">
+                  <NsTextInput
+                    v-model.trim="maximal_queue_lifetime"
+                    ref="maximal_queue_lifetime"
+                    :invalid-message="$t(error.maximal_queue_lifetime)"
+                    type="number"
+                    min="1"
+                    max="200"
+                    placeholder="120"
+                    :label="$t('settings_queue.maximal_queue_lifetime')"
+                    :helper-text="
+                      $t('settings_queue.maximal_queue_lifetime_helper')
+                    "
+                    tooltipAlignment="start"
+                    tooltipDirection="right"
+                    :disabled="
+                      loading.getQueueSettings || loading.setQueueSettings
+                    "
+                  >
+                    <template slot="tooltip">
+                      {{ $t("settings_queue.maximal_queue_lifetime_tooltip") }}
+                    </template>
+                  </NsTextInput>
+
+                  <NsButton
+                    kind="secondary"
+                    :icon="Save20"
+                    :loading="loading.setQueueSettings"
+                    :disabled="
+                      loading.getQueueSettings || loading.setQueueSettings
+                    "
+                    >{{ $t("common.save_settings") }}</NsButton
+                  >
+                </cv-form>
+              </cv-column>
+            </cv-row>
+          </cv-grid>
+        </cv-tile>
+      </cv-column>
+    </cv-row>
+  </cv-grid>
+</template>
+
+<script>
+import to from "await-to-js";
+import {
+  QueryParamService,
+  UtilService,
+  TaskService,
+  IconService,
+  PageTitleService,
+} from "@nethserver/ns8-ui-lib";
+import { mapState } from "vuex";
+
+export default {
+  name: "SettingsQueue",
+  mixins: [
+    TaskService,
+    UtilService,
+    IconService,
+    QueryParamService,
+    PageTitleService,
+  ],
+  pageTitle() {
+    return this.$t("settings_mailboxes.title") + " - " + this.appName;
+  },
+  data() {
+    return {
+      q: {
+        page: "settingsQueue",
+      },
+      urlCheckInterval: null,
+      maximal_queue_lifetime: "120",
+      loading: {
+        getQueueSettings: false,
+        setQueueSettings: false,
+      },
+      error: {
+        getQueueSettings: "",
+        setQueueSettings: "",
+        maximal_queue_lifetime: "",
+      },
+    };
+  },
+  computed: {
+    ...mapState(["core", "appName", "instanceName"]),
+  },
+  watch: {},
+  beforeRouteEnter(to, from, next) {
+    next((vm) => {
+      vm.watchQueryData(vm);
+      vm.urlCheckInterval = vm.initUrlBindingForApp(vm, vm.q.page);
+    });
+  },
+  beforeRouteLeave(to, from, next) {
+    clearInterval(this.urlCheckInterval);
+    next();
+  },
+  created() {
+    this.getQueueSettings();
+  },
+  methods: {
+    goToSettings() {
+      this.goToAppPage(this.instanceName, "settings");
+    },
+    async getQueueSettings() {
+      this.loading.getQueueSettings = true;
+      this.error.getQueueSettings = "";
+      const taskAction = "get-queue-settings";
+      const eventId = this.getUuid();
+
+      // register to task error
+      this.core.$root.$once(
+        `${taskAction}-aborted-${eventId}`,
+        this.getQueueSettingsAborted
+      );
+
+      // register to task completion
+      this.core.$root.$once(
+        `${taskAction}-completed-${eventId}`,
+        this.getQueueSettingsCompleted
+      );
+
+      const res = await to(
+        this.createModuleTaskForApp(this.instanceName, {
+          action: taskAction,
+          extra: {
+            title: this.$t("action." + taskAction),
+            isNotificationHidden: true,
+            eventId,
+          },
+        })
+      );
+      const err = res[0];
+
+      if (err) {
+        console.error(`error creating task ${taskAction}`, err);
+        this.error.getQueueSettings = this.getErrorMessage(err);
+        this.loading.getQueueSettings = false;
+        return;
+      }
+    },
+    getQueueSettingsAborted(taskResult, taskContext) {
+      console.error(`${taskContext.action} aborted`, taskResult);
+      this.error.getQueueSettings = this.$t("error.generic_error");
+      this.loading.getQueueSettings = false;
+    },
+    getQueueSettingsCompleted(taskContext, taskResult) {
+      this.loading.getQueueSettings = false;
+      this.maximal_queue_lifetime = taskResult.output.maximal_queue_lifetime;
+    },
+    validateSetQueueSettings() {
+      this.clearErrors();
+      let isValidationOk = true;
+
+      if (!this.maximal_queue_lifetime) {
+        this.error.maximal_queue_lifetime = this.$t("common.required");
+
+        if (isValidationOk) {
+          this.focusElement("maximal_queue_lifetime");
+          isValidationOk = false;
+        }
+      }
+      return isValidationOk;
+    },
+    async setQueueSettings() {
+      if (!this.validateSetQueueSettings()) {
+        return;
+      }
+      this.loading.setQueueSettings = true;
+      this.error.setQueueSettings = "";
+      this.error.maximal_queue_lifetime = "";
+      const taskAction = "set-queue-settings";
+      const eventId = this.getUuid();
+
+      // register to task error
+      this.core.$root.$once(
+        `${taskAction}-aborted-${eventId}`,
+        this.setQueueSettingsAborted
+      );
+
+      // register to task validation
+      this.core.$root.$once(
+        `${taskAction}-validation-failed-${eventId}`,
+        this.setQueueSettingsValidationFailed
+      );
+
+      // register to task completion
+      this.core.$root.$once(
+        `${taskAction}-completed-${eventId}`,
+        this.setQueueSettingsCompleted
+      );
+
+      const res = await to(
+        this.createModuleTaskForApp(this.instanceName, {
+          action: taskAction,
+          data: {
+            maximal_queue_lifetime: parseInt(this.maximal_queue_lifetime),
+          },
+          extra: {
+            title: this.$t("action." + taskAction),
+            description: this.$t("common.processing"),
+            eventId,
+          },
+        })
+      );
+      const err = res[0];
+
+      if (err) {
+        console.error(`error creating task ${taskAction}`, err);
+        this.error.setQueueSettings = this.getErrorMessage(err);
+        this.loading.setQueueSettings = false;
+        return;
+      }
+    },
+    setQueueSettingsAborted(taskResult, taskContext) {
+      console.error(`${taskContext.action} aborted`, taskResult);
+      this.error.setQueueSettings = this.$t("error.generic_error");
+      this.loading.setQueueSettings = false;
+    },
+    setQueueSettingsValidationFailed(validationErrors) {
+      this.loading.setQueueSettings = false;
+      let focusAlreadySet = false;
+
+      for (const validationError of validationErrors) {
+        const param = validationError.parameter;
+
+        // set i18n error message
+        this.error[param] = this.getI18nStringWithFallback(
+          "settings_mailboxes." + validationError.error,
+          "error." + validationError.error,
+          this.core
+        );
+
+        if (!focusAlreadySet && param != "(root)") {
+          this.focusElement(param);
+          focusAlreadySet = true;
+        }
+      }
+    },
+    setQueueSettingsCompleted() {
+      this.loading.setQueueSettings = false;
+
+      // reload settings
+      this.getQueueSettings();
+    },
+  },
+};
+</script>
+
+<style scoped lang="scss">
+@import "../../styles/carbon-utils";
+
+.cv-form .bx--form-item {
+  margin-bottom: $spacing-07;
+}
+
+.toggle-dependent {
+  margin-bottom: $spacing-07;
+}
+</style>

--- a/ui/src/views/settings/SettingsQueue.vue
+++ b/ui/src/views/settings/SettingsQueue.vue
@@ -64,8 +64,6 @@
                     ref="maximal_queue_lifetime"
                     :invalid-message="$t(error.maximal_queue_lifetime)"
                     type="number"
-                    min="1"
-                    max="200"
                     placeholder="120"
                     :label="$t('settings_queue.maximal_queue_lifetime')"
                     :helper-text="
@@ -215,7 +213,28 @@ export default {
 
       if (!this.maximal_queue_lifetime) {
         this.error.maximal_queue_lifetime = this.$t("common.required");
-
+        if (isValidationOk) {
+          this.focusElement("maximal_queue_lifetime");
+          isValidationOk = false;
+        }
+      } else if (
+        this.maximal_queue_lifetime &&
+        parseInt(this.maximal_queue_lifetime) < 1
+      ) {
+        this.error.maximal_queue_lifetime = this.$t(
+          "settings_queue.must_be_superior_or_equal_to_1"
+        );
+        if (isValidationOk) {
+          this.focusElement("maximal_queue_lifetime");
+          isValidationOk = false;
+        }
+      } else if (
+        this.maximal_queue_lifetime &&
+        parseInt(this.maximal_queue_lifetime) > 200
+      ) {
+        this.error.maximal_queue_lifetime = this.$t(
+          "settings_queue.must_be_inferior_or_equal_to_200"
+        );
         if (isValidationOk) {
           this.focusElement("maximal_queue_lifetime");
           isValidationOk = false;


### PR DESCRIPTION
This pull request adds the `maximal_queue_lifetime` configuration to the `main.cf` file in the Postfix repository. The `maximal_queue_lifetime` setting specifies the maximum time a message can remain in the queue before it is automatically removed. This configuration option allows users to customize the queue lifetime according to their specific needs.

![image](https://github.com/NethServer/ns8-mail/assets/3164851/2ecce86d-1573-4604-9d0a-3f29d09a1824)

![image](https://github.com/NethServer/ns8-mail/assets/3164851/4df11036-2b7d-41b7-9af2-6e9b21539427)

![image](https://github.com/NethServer/ns8-mail/assets/3164851/1952696d-85a2-4d74-bbf9-676c01a103be)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/214148e9-0785-4361-a037-a8a217588b69)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/397b0fb0-9926-4e57-a61a-6486f6f09981)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/79d2a172-aaf9-4a3f-aa62-e05fee7a484b)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/7d3c59c8-ceea-4ea2-97d4-2f3081b945af)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/b8817e1c-20f1-429d-a6b8-1ba69f3e8f16)
![image](https://github.com/NethServer/ns8-mail/assets/3164851/5fec7e30-ae31-4e3f-87bf-e55fef97776f)


Refs https://github.com/NethServer/dev/issues/6886