### PR TITLE
Fix missing SEEN flags after restore

### DIFF
--- a/imageroot/etc/state-exclude.conf
+++ b/imageroot/etc/state-exclude.conf
@@ -4,4 +4,5 @@
 # Restic --files-from: https://restic.readthedocs.io/en/stable/040_backup.html#excluding-files
 #
 volumes/dovecot-data/**/dovecot.index*
+!volumes/dovecot-data/**/dovecot.index.pvt*
 volumes/dovecot-data/**/fts-flatcurve


### PR DESCRIPTION
Include in the backup the Dovecot INDEXPVT files that record the SEEN flag state.

Refs NethServer/dev#6880