### PR TITLE
Fix restore of DOVECOT_SHAREDSEEN flag

### DIFF
--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -20,6 +20,7 @@ for evar in [
         "DOVECOT_TRUSTED_NETWORKS",
         "POSTFIX_TRUSTED_NETWORK",
         "DOVECOT_MASTER_USERS",
+        "DOVECOT_SHAREDSEEN",
     ]:
     if evar in original_environment:
         agent.set_env(evar, original_environment[evar])


### PR DESCRIPTION
The flag is included in the backup, but its value is not restored correctly.

Refs NethServer/dev#6880