### PR TITLE
Add support for spam subject prefix in mailbox settings

### DIFF
--- a/imageroot/actions/get-filter-configuration/10get_filter_configuration
+++ b/imageroot/actions/get-filter-configuration/10get_filter_configuration
@@ -49,13 +49,5 @@ odata["antispam"]["greylist"] = {
     "enabled": bool(os.getenv('RSPAMD_greylist_enabled')),
     "threshold": thm.get("greylist", greylist_fallback_threshold),
 }
-# NOTE: subject prefix for suspect messages is handled by Dovecot with a global Sieve rule:
-if os.getenv("DOVECOT_SPAM_SUBJECT_PREFIX"):
-    odata["antispam"]["prefix_email_subject"] = {
-        "enabled": True,
-        "prefix": os.environ["DOVECOT_SPAM_SUBJECT_PREFIX"],
-    }
-else:
-    odata["antispam"]["prefix_email_subject"] = {"enabled": False, "prefix": "***SPAM***"}
 
 json.dump(odata, fp=sys.stdout)

--- a/imageroot/actions/get-filter-configuration/validate-output.json
+++ b/imageroot/actions/get-filter-configuration/validate-output.json
@@ -14,10 +14,6 @@
         "greylist": {
           "enabled": true,
           "threshold": 4
-        },
-        "prefix_email_subject": {
-          "enabled": true,
-          "prefix": "***SPAM***"
         }
       },
       "antivirus": {

--- a/imageroot/actions/get-mailbox-settings/10get_mailbox_settings
+++ b/imageroot/actions/get-mailbox-settings/10get_mailbox_settings
@@ -33,6 +33,11 @@ ospam_folder = {
     "enabled": False,
 }
 
+ospam_prefix = {
+    "enabled": False,
+    "prefix": "***SPAM***",
+}
+
 if os.getenv("DOVECOT_SPAM_FOLDER"):
     ospam_folder = {
         "enabled": True,
@@ -43,9 +48,16 @@ osharedseen = {
     "enabled": os.getenv("DOVECOT_SHAREDSEEN", '') != ""
 }
 
+if os.getenv("DOVECOT_SPAM_SUBJECT_PREFIX"):
+    ospam_prefix = {
+        "enabled": True,
+        "prefix": os.getenv("DOVECOT_SPAM_SUBJECT_PREFIX"),
+    }
+
 json.dump({
     "quota": oquota,
     "spam_retention": ospam_retention,
     "spam_folder": ospam_folder,
     "sharedseen": osharedseen,
+    "spam_prefix": ospam_prefix
 }, fp=sys.stdout)

--- a/imageroot/actions/get-mailbox-settings/validate-output.json
+++ b/imageroot/actions/get-mailbox-settings/validate-output.json
@@ -17,6 +17,10 @@
             },
             "sharedseen": {
                 "enabled": true
+            },
+            "spam_prefix": {
+                "enabled": true,
+                "prefix": "SPAM"
             }
         },
         {
@@ -31,6 +35,9 @@
             },
             "sharedseen": {
                 "enabled": false
+            },
+            "spam_prefix": {
+                "enabled": false
             }
         }
     ],
@@ -40,7 +47,8 @@
         "spam_retention",
         "spam_folder",
         "quota",
-        "sharedseen"
+        "sharedseen",
+        "spam_prefix"
     ],
     "properties": {
         "spam_folder": {
@@ -54,6 +62,9 @@
         },
         "sharedseen": {
             "$ref": "http://schema.nethserver.org/mail.json#/$defs/sharedseen-status"
+        },
+        "spam_prefix": {
+            "$ref": "http://schema.nethserver.org/mail.json#/$defs/spam-prefix"
         }
     }
 }

--- a/imageroot/actions/import-module/20import_environment
+++ b/imageroot/actions/import-module/20import_environment
@@ -19,7 +19,7 @@ agent.set_env('POSTFIX_ORIGIN', open('user_domain.txt').read().strip())
 
 # Spam subject prefix migration
 if type(jrspamd) is dict and jrspamd['props'].get('SpamSubjectPrefixStatus') == 'enabled':
-    agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', jrspamd['props'].get('SpamSubjectPrefixString', '***SPAM***'))
+    agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', jrspamd['props'].get('SpamSubjectPrefixString', ''))
 else:
     agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', '')
 

--- a/imageroot/actions/import-module/20import_environment
+++ b/imageroot/actions/import-module/20import_environment
@@ -19,7 +19,7 @@ agent.set_env('POSTFIX_ORIGIN', open('user_domain.txt').read().strip())
 
 # Spam subject prefix migration
 if type(jrspamd) is dict and jrspamd['props'].get('SpamSubjectPrefixStatus') == 'enabled':
-    agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', jrspamd['props'].get('SpamSubjectPrefixString', ''))
+    agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', jrspamd['props'].get('SpamSubjectPrefixString', '***SPAM***'))
 else:
     agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', '')
 

--- a/imageroot/actions/restore-module/70configure_module
+++ b/imageroot/actions/restore-module/70configure_module
@@ -27,6 +27,10 @@ settings_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='set-m
         "enabled": bool(renv.get("DOVECOT_SPAM_FOLDER", "")),
         "name": renv.get("DOVECOT_SPAM_FOLDER", "Junk")
     },
+    "spam_prefix": {
+        "enabled": bool(renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "")),
+        "prefix": renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "***SPAM***")
+    },
     "quota": {
         "limit": int(renv.get("DOVECOT_QUOTA_MB", "0"))
     }

--- a/imageroot/actions/restore-module/70configure_module
+++ b/imageroot/actions/restore-module/70configure_module
@@ -29,7 +29,7 @@ settings_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='set-m
     },
     "spam_prefix": {
         "enabled": bool(renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "")),
-        "prefix": renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "***SPAM***")
+        "prefix": renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "")
     },
     "quota": {
         "limit": int(renv.get("DOVECOT_QUOTA_MB", "0"))

--- a/imageroot/actions/set-filter-configuration/10set_filter_configuration
+++ b/imageroot/actions/set-filter-configuration/10set_filter_configuration
@@ -58,10 +58,5 @@ if 'antispam' in request:
 
         mail.rspamd_api_set_thresholds(thm)
 
-        if 'prefix_email_subject' in ras:
-            if ras['prefix_email_subject']['enabled'] and 'prefix' in ras['prefix_email_subject']:
-                agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', ras['prefix_email_subject']['prefix'])
-            else:
-                agent.set_env('DOVECOT_SPAM_SUBJECT_PREFIX', '')
     else: # ras['enabled'] is false
         agent.set_env('RSPAMD_antispam_checks_enabled', '')

--- a/imageroot/actions/set-filter-configuration/validate-input.json
+++ b/imageroot/actions/set-filter-configuration/validate-input.json
@@ -26,10 +26,6 @@
         "deny_message_threshold": 20,
         "greylist": {
           "enabled": false
-        },
-        "prefix_email_subject": {
-          "enabled": true,
-          "prefix": "***SPAM***"
         }
       }
     }

--- a/imageroot/actions/set-mailbox-settings/10set_mailbox_settings
+++ b/imageroot/actions/set-mailbox-settings/10set_mailbox_settings
@@ -31,3 +31,10 @@ if 'spam_retention' in request:
 if 'sharedseen' in request:
     sharedseen = request['sharedseen']['enabled']
     agent.set_env("DOVECOT_SHAREDSEEN", "1" if sharedseen else "")
+
+if 'spam_prefix' in request:
+    if request['spam_prefix']['enabled'] == True:
+        spam_prefix = request['spam_prefix']['prefix']
+    else:
+        spam_prefix = ""
+    agent.set_env("DOVECOT_SPAM_SUBJECT_PREFIX", spam_prefix)

--- a/imageroot/actions/set-mailbox-settings/validate-input.json
+++ b/imageroot/actions/set-mailbox-settings/validate-input.json
@@ -17,6 +17,10 @@
             },
             "sharedseen": {
                 "enabled": true
+            },
+            "spam_prefix": {
+                "enabled": true,
+                "prefix": "***SPAM***"
             }
         }
     ],
@@ -34,6 +38,9 @@
         },
         "sharedseen": {
             "$ref": "http://schema.nethserver.org/mail.json#/$defs/sharedseen-status"
+        },
+        "spam_prefix": {
+            "$ref": "http://schema.nethserver.org/mail.json#/$defs/spam-prefix"
         }
     }
 }

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -441,6 +441,48 @@
                 }
             }
         },
+        "spam-prefix": {
+            "type": "object",
+            "title": "Spam prefix",
+            "description": "Decide if and how to prefix the subject of messages marked as spam",
+            "oneOf": [
+                {
+                    "title": "Spam prefix enabled",
+                    "required": [
+                        "enabled",
+                        "prefix"
+                    ],
+                    "properties": {
+                        "enabled": {
+                            "const": true
+                        }
+                    }
+                },
+                {
+                    "title": "Spam prefix disabled",
+                    "required": [
+                        "enabled"
+                    ],
+                    "properties": {
+                        "enabled": {
+                            "const": false
+                        }
+                    }
+                }
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "title": "Enable folder"
+                },
+                "prefix": {
+                    "type": "string",
+                    "title": "Folder prefix",
+                    "minLength": 1
+                }
+            }
+        },
         "spam-retention": {
             "type": "object",
             "title": "Spam retention",

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -478,8 +478,7 @@
                 },
                 "prefix": {
                     "type": "string",
-                    "title": "Folder prefix",
-                    "minLength": 1
+                    "title": "Folder prefix"
                 }
             }
         },

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -868,25 +868,6 @@
                             "type": "number"
                         }
                     }
-                },
-                "prefix_email_subject": {
-                    "type": "object",
-                    "title": "Prefix email subject",
-                    "description": "Configure if the subject of spam messages are prefixed with a string",
-                    "required": [
-                        "enabled"
-                    ],
-                    "properties": {
-                        "enabled": {
-                            "description": "Defines if email subject prefixing",
-                            "type": "boolean"
-                        },
-                        "prefix": {
-                            "description": "Prefix for the subject of spam messages",
-                            "type": "string",
-                            "minLength": 1
-                        }
-                    }
                 }
             }
         },

--- a/ui/src/views/MailFilter.vue
+++ b/ui/src/views/MailFilter.vue
@@ -242,42 +242,6 @@
                       @unlimited="antispam.greylist.enabled = !$event"
                       class="mg-bottom-xlg"
                     />
-                    <!-- add a prefix to spam messages subject (the same component is in Settings/Mailboxes) -->
-                    <NsToggle
-                      value="prefixSpamValue"
-                      :form-item="true"
-                      v-model="antispam.prefix_email_subject.enabled"
-                      :disabled="
-                        loading.getFilterConfiguration ||
-                        loading.setFilterConfiguration
-                      "
-                      :class="[
-                        'toggle-without-label',
-                        {
-                          'mg-bottom-md': antispam.prefix_email_subject.enabled,
-                        },
-                      ]"
-                      ref="isAddPrefixToSpamSubject"
-                    >
-                      <template slot="text-left">{{
-                        $t("filter.add_prefix_to_spam_subject")
-                      }}</template>
-                      <template slot="text-right">{{
-                        $t("filter.add_prefix_to_spam_subject")
-                      }}</template>
-                    </NsToggle>
-                    <NsTextInput
-                      v-if="antispam.prefix_email_subject.enabled"
-                      v-model.trim="antispam.prefix_email_subject.prefix"
-                      :label="$t('filter.prefix')"
-                      :invalid-message="error.prefix_email_subject"
-                      :disabled="
-                        loading.getFilterConfiguration ||
-                        loading.setFilterConfiguration
-                      "
-                      class="toggle-dependent"
-                      ref="prefix_email_subject"
-                    />
                   </template>
                 </cv-accordion-item>
               </cv-accordion>
@@ -462,10 +426,6 @@ export default {
           enabled: false,
           threshold: "1",
         },
-        prefix_email_subject: {
-          enabled: false,
-          prefix: "",
-        },
       },
       antivirus: {
         enabled: false,
@@ -497,7 +457,6 @@ export default {
         spam_flag_threshold: "",
         deny_message_threshold: "",
         greylist: "",
-        prefix_email_subject: "",
       },
     };
   },
@@ -513,15 +472,7 @@ export default {
       return this.antivirus.third_party_sigs_rating === "high";
     },
   },
-  watch: {
-    "antispam.prefix_email_subject.enabled": function () {
-      if (this.antispam.prefix_email_subject.enabled) {
-        this.$nextTick(() => {
-          this.focusElement("prefix_email_subject");
-        });
-      }
-    },
-  },
+  watch: {},
   beforeRouteEnter(to, from, next) {
     next((vm) => {
       vm.watchQueryData(vm);
@@ -771,17 +722,6 @@ export default {
       this.getFilterConfiguration();
     },
     saveAntispamSection() {
-      // validate spam prefix
-      this.error.prefix_email_subject = "";
-
-      if (
-        this.antispam.prefix_email_subject.enabled &&
-        !this.antispam.prefix_email_subject.prefix
-      ) {
-        this.focusElement("prefix_email_subject");
-        this.error.prefix_email_subject = this.$t("common.required");
-        return;
-      }
 
       const actionPayload = {
         antispam: {
@@ -792,16 +732,8 @@ export default {
             enabled: this.antispam.greylist.enabled,
             threshold: Number(this.antispam.greylist.threshold),
           },
-          prefix_email_subject: {
-            enabled: this.antispam.prefix_email_subject.enabled,
-          },
         },
       };
-
-      if (this.antispam.prefix_email_subject.enabled) {
-        actionPayload.antispam.prefix_email_subject.prefix =
-          this.antispam.prefix_email_subject.prefix;
-      }
       this.loading.saveAntispamSection = true;
       this.setFilterConfiguration(actionPayload, "antispam");
     },

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -430,6 +430,11 @@ export default {
         this.spamFolder.name = "";
       }
       this.sharedseen.enabled = settings.sharedseen.enabled;
+
+    // spam prefix
+     this.addPrefixToSpamSubject.enabled = settings.spam_prefix.enabled;
+     this.addPrefixToSpamSubject.prefix  = settings.spam_prefix.prefix;
+
     },
     validateSetMailboxSettings() {
       this.clearErrors();
@@ -444,6 +449,16 @@ export default {
 
         if (isValidationOk) {
           this.focusElement("spam_folder");
+          isValidationOk = false;
+        }
+      }
+      if (this.addPrefixToSpamSubject.enabled && !this.addPrefixToSpamSubject.prefix) {
+        this.error.spamSubjectPrefix = this.$t(
+          "common.required"
+        );
+
+        if (isValidationOk) {
+          this.focusElement("spamSubjectPrefix");
           isValidationOk = false;
         }
       }
@@ -517,6 +532,16 @@ export default {
         enabled: this.sharedseen.enabled,
       };
 
+      // spam prefix
+
+      let spamPrefix = {
+        enabled: this.addPrefixToSpamSubject.enabled,
+      };
+
+      if (this.addPrefixToSpamSubject.enabled) {
+        spamPrefix.prefix = this.addPrefixToSpamSubject.prefix;
+      }
+
       const res = await to(
         this.createModuleTaskForApp(this.instanceName, {
           action: taskAction,
@@ -525,6 +550,7 @@ export default {
             spam_folder: spamFolder,
             spam_retention: spamRetention,
             sharedseen: sharedseen,
+            spam_prefix: spamPrefix,
           },
           extra: {
             title: this.$t("action." + taskAction),


### PR DESCRIPTION
does adds support for 

- add  a spam subject prefix in the mailbox settings. 
- remove spam prefix settings from filters > antispam vue page 

refs: https://github.com/NethServer/dev/issues/6898


[Capture vidéo du 2024-03-22 14-39-02.webm](https://github.com/NethServer/ns8-mail/assets/3164851/8ddc357f-7764-4e34-be1a-d0b26ec11b4a)
