### PR TITLE
Fix mixed case domain name comparisons

### DIFF
--- a/postfix/etc/postfix/pcdb-init.sql
+++ b/postfix/etc/postfix/pcdb-init.sql
@@ -49,9 +49,9 @@ CREATE TABLE domains (
 -- (wildcard domain) value can be used in the "domain" column. It will
 -- match any domain in the "domains" table.
 CREATE TABLE destmap (
-    alocal TEXT NOT NULL,
+    alocal TEXT NOT NULL COLLATE NOCASE,
     -- local part of the address (e.g. "john" in "john@example.com")
-    domain TEXT NOT NULL,
+    domain TEXT NOT NULL COLLATE NOCASE,
     -- domain part of the address (e.g. "example.com" in "john@example.com")
     dest TEXT NOT NULL,
     -- destination (an external address or virtual mailbox name)
@@ -61,9 +61,9 @@ CREATE TABLE destmap (
 
 -- addresses -- address attributes
 CREATE TABLE addresses (
-    alocal TEXT NOT NULL,
+    alocal TEXT NOT NULL COLLATE NOCASE,
     -- local part of the address (e.g. "john" in "john@example.com")
-    domain TEXT NOT NULL,
+    domain TEXT NOT NULL COLLATE NOCASE,
     -- domain part of the address (e.g. "example.com" in "john@example.com")
     internal INT DEFAULT 0,
     -- if set to 1, external MTA and unauthenticated MUA cannot send
@@ -76,7 +76,7 @@ CREATE TABLE addresses (
 
 -- userattrs -- user attributes
 CREATE TABLE userattrs (
-    user TEXT NOT NULL,
+    user TEXT NOT NULL COLLATE NOCASE,
     -- the LDAP user identifier, (e.g. "first.user")
     internal INT DEFAULT 0,
     -- if set to 1, external MTA and unauthenticated MUA cannot send
@@ -88,7 +88,7 @@ CREATE TABLE userattrs (
 -- given user, a record with user == dest means a copy of each message is
 -- also stored on the local server
 CREATE TABLE userforwards (
-    user TEXT NOT NULL,
+    user TEXT NOT NULL COLLATE NOCASE,
     -- the LDAP user identifier, (e.g. "first.user")
     dest TEXT NOT NULL,
     -- destination (an external address or virtual mailbox name)
@@ -97,7 +97,7 @@ CREATE TABLE userforwards (
 
 -- groupattrs -- group attributes
 CREATE TABLE groupattrs (
-    "group" TEXT NOT NULL,
+    "group" TEXT NOT NULL COLLATE NOCASE,
     -- the LDAP group identifier, (e.g. "sales")
     internal INT DEFAULT 0,
     -- if set to 1, external MTA and unauthenticated MUA cannot send


### PR DESCRIPTION
If the configured domain name is in mixed case, the expansion of Postfix configuration generates a bad result, leading to unaccessible addresses (Access denied). This DB schema fix enables case-insensitive matches for the domains key.

The COLLATE NOCASE is effective also in new record insertion, to prevent inserting the same domain multiple times with different letter case.

Additional columns changed to COLLATE NOCASE, to fix more failure cases:
- I enter a mixed-case address like `DuDE@example.org`
- LDAP returns users and groups with mixed case names (e.g. Administrator)

Refs https://github.com/NethServer/dev/issues/6906


![image](https://github.com/NethServer/ns8-mail/assets/2920838/d944db5e-06ee-4e62-9eb7-4db9c43ba434)


As the issue rarely occurs, the PR does not alter the DB schema of existing installations.
