### PR TITLE
Set TLS connection type: smtps/starttls

### DIFF
--- a/imageroot/actions/add-relay-rule/10test-credentials
+++ b/imageroot/actions/add-relay-rule/10test-credentials
@@ -23,10 +23,6 @@ password = data['password']
 rule_type = data['rule_type']
 rule_subject = data['rule_subject']
 
-# if the username is empty, we do not need to validate
-if not username:
-    sys.exit(0)
-
 def get_password_from_database(rule_subject):
     # Function to query the database for the password based rule_subject
     sdb = mail.pcdb_connect()
@@ -43,7 +39,7 @@ def get_password_from_database(rule_subject):
         sys.exit(6)
 
 # password not changed, we need to retrieve it from the database
-if password == '':
+if username and password == '':
     password = get_password_from_database(rule_subject)
 
 port =  int(data['port'])
@@ -61,14 +57,14 @@ try :
         try:
             smtp = smtplib.SMTP(host, port=port, timeout=10)
             smtp.starttls(context=ctx)
-        # if the server does not support starttls we try with smtps
-        except smtplib.SMTPNotSupportedError:
+        except Exception as ex:
+            print(agent.SD_WARNING+"STARTTLS seems not supported. Fall back to SMTPS", ex, file=sys.stderr) 
             smtp = smtplib.SMTP_SSL(host, port=port, timeout=10, context=ctx)
     else:
         smtp = smtplib.SMTP(host, port=port, timeout=10)
 
     # we have a login, we try to authenticate.
-    if username:
+    if username and password:
         smtp.login(username, password)
     # without authentication, we have now way to test except 
     # to connect to the server. we quit


### PR DESCRIPTION
This pull request fixes the TLS connection issue in the add-relay-rule/10test-credentials file. Previously, the code only attempted to connect using starttls, but now it also tries smtps if starttls fails. This ensures a more reliable and secure connection.

https://github.com/NethServer/dev/issues/6895