### PR TITLE
Fix relay rule validation error messages

### DIFF
--- a/imageroot/actions/add-relay-rule/10test-credentials
+++ b/imageroot/actions/add-relay-rule/10test-credentials
@@ -35,7 +35,7 @@ def get_password_from_database(rule_subject):
         return result[0]
     else:
         agent.set_status('validation-failed')
-        json.dump([{'field':'test_rule_credentials','parameter':'test_rule_credentials','value':'cannot_retrieve_password_user_from_sqlite','error':'cannot_retrieve_password_user_from_sqlite'}],fp=sys.stdout, default=str)
+        json.dump([{'field':'password','parameter':'password','value':'cannot_retrieve_password_user_from_sqlite','error':'cannot_retrieve_password_user_from_sqlite'}],fp=sys.stdout, default=str)
         sys.exit(6)
 
 # password not changed, we need to retrieve it from the database
@@ -74,21 +74,21 @@ except smtplib.SMTPAuthenticationError as err:
     print(agent.SD_NOTICE + "smtplib validation:", err, file=sys.stderr)
     agent.set_status('validation-failed')
     # probably name or password failure
-    json.dump([{'field':'test_rule_credentials','parameter':'test_rule_credentials','value':err,'error':'cannot_authenticate_to_server'}],fp=sys.stdout, default=str)
+    json.dump([{'field':'username','parameter':'username','value':err,'error':'cannot_authenticate_to_server'}],fp=sys.stdout, default=str)
     sys.exit(2)
 
 except smtplib.SMTPConnectError as err:
     print(agent.SD_NOTICE + "smtplib validation:", err, file=sys.stderr)
     agent.set_status('validation-failed')
     # any connection error to the server
-    json.dump([{'field':'test_rule_credentials','parameter':'test_rule_credentials','value':err,'error':'cannot_connect_to_server'}],fp=sys.stdout, default=str)
+    json.dump([{'field':'host','parameter':'host','value':err,'error':'cannot_connect_to_server'}],fp=sys.stdout, default=str)
     sys.exit(3)
 
 except smtplib.SMTPNotSupportedError as err:
     print(agent.SD_NOTICE + "smtplib validation:", err, file=sys.stderr)
     agent.set_status('validation-failed')
     # probably need to use starttls
-    json.dump([{'field':'test_rule_credentials','parameter':'test_rule_credentials','value':err,'error':'connection_not_supported_by_server'}],fp=sys.stdout, default=str)
+    json.dump([{'field':'host','parameter':'host','value':err,'error':'connection_not_supported_by_server'}],fp=sys.stdout, default=str)
     sys.exit(4)
 
 except smtplib.socket.gaierror as err:
@@ -101,5 +101,5 @@ except smtplib.socket.error as err:
     print(agent.SD_NOTICE + "smtplib validation:", err, file=sys.stderr)
     agent.set_status('validation-failed')
     # We have issued a timeout, the server is not responding or the URL is wrong
-    json.dump([{'field':'test_rule_credentials','parameter':'test_rule_credentials','value':err,'error':'connection_timeout_error'}],fp=sys.stdout, default=str)
+    json.dump([{'field':'host','parameter':'host','value':err,'error':'connection_timeout_error'}],fp=sys.stdout, default=str)
     sys.exit(5)


### PR DESCRIPTION
This pull request fixes the error messages in the relay rule validation process. The error messages now correctly reference the fields 'password', 'username', and 'host' instead of 'test_rule_credentials' that does not exist in the UI

https://github.com/NethServer/dev/issues/6895

Now the error is displayed in the field in error (smtp host and username/password)