### PR TITLE
Fix default relay rule selection priority

### DIFF
--- a/postfix/etc/postfix/relaydest.cf
+++ b/postfix/etc/postfix/relaydest.cf
@@ -7,6 +7,5 @@ dbpath = /srv/pcdb.sqlite
 query = SELECT FORMAT('%%s:[%%s]:%%s', transport, host, port) AS route
   FROM relayrules
   WHERE enabled = 1 AND (
-    (rule_subject = '%s' AND rule_type IN ('recipient', 'always-bcc'))
-    OR (rule_subject = '*' AND rule_type = 'wildcard')
+    rule_subject = '%s' AND rule_type IN ('recipient', 'always-bcc', 'wildcard')
   )


### PR DESCRIPTION
The SQL query is wrong: it always matches the wildcard record if present!

Postfix runs the query replacing %s with "*".

Refs NethServer/dev#6895