### PR TITLE
Migrate the NS7 smarthost configuration in relayrules table

### DIFF
--- a/imageroot/actions/import-module/49import_smarthosts
+++ b/imageroot/actions/import-module/49import_smarthosts
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import os
 import sys
 import json
 import agent
@@ -35,8 +36,8 @@ with sdb:
             'password': smart['props'].get('Password'),
             'enabled': True if smart['props'].get('status') == 'enabled' else False,
         }
-        cur.execute("""INSERT INTO relayrules (rule_type, rule_subject , host, port, tls, username, password, enabled) 
-                    VALUES (:rule_type, :rule_subject, :host, :port, :mandatory_tls, :username, :password, :enabled)""", vals)
+        cur.execute("""INSERT INTO relayrules (rule_type, rule_subject , transport, host, port, tls, username, password, enabled) 
+                    VALUES (:rule_type, :rule_subject, 'smtp', :host, :port, :mandatory_tls, :username, :password, :enabled)""", vals)
 
 
     # Import config printjson postfix output:
@@ -47,6 +48,19 @@ with sdb:
     SenderValidation = jpostfix['props'].get('SenderValidation') == 'enabled'
     postfix_restricted_sender = '1' if SenderValidation else ''
     agent.set_env('POSTFIX_RESTRICTED_SENDER', postfix_restricted_sender)
+    # set the NS7 postfix smarthost
+    SmartHostStatus = jpostfix['props'].get('SmartHostStatus', 'disabled') == 'enabled'
+    if SmartHostStatus:
+        vals = {
+            'host': jpostfix['props'].get('SmartHostName'),
+            'port': int(jpostfix['props'].get('SmartHostPort')),
+            'username': jpostfix['props'].get('SmartHostUsername'),
+            'password': jpostfix['props'].get('SmartHostPassword'),
+            'tls': 'encrypt' if jpostfix['props'].get('SmartHostTlsStatus') == 'enabled' else 'may',
+            'enabled': True if jpostfix['props'].get('SmartHostStatus') == 'enabled' else False,
+        }
+        cur.execute("""INSERT INTO relayrules (rule_type, rule_subject , transport, host, port, tls, username, password, enabled) 
+                    VALUES ('wildcard', '*', 'smtp', :host, :port, :tls, :username, :password, :enabled)""", vals)
 
     # Set the network table (AccessBypassList)
     print(agent.SD_INFO + "Importing network table...", file=sys.stderr)


### PR DESCRIPTION
This pull request refactors the smarthost configuration in the relayrules table. It adds the ability to set the smarthost for the NS7 postfix and inserts the necessary values into the relayrules table. This allows for more flexible and configurable smarthost settings.

https://github.com/NethServer/dev/issues/6895

tested with ghcr.io/nethserver/core:2.8.0-dev.1 and ghcr.io/nethserver/mail:sdl-6895-import-NS7-credentials

linked to https://github.com/NethServer/nethserver-ns8-migration/pull/68