### PR TITLE
Add cyrus-sasl-login package to postfix installation

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -127,7 +127,7 @@ reponame="mail-postfix"
 container=$(buildah from docker.io/library/alpine:${alpine_version})
 buildah run "${container}" /bin/sh <<EOF
 set -e
-apk add --no-cache postfix gettext sqlite postfix-sqlite postfix-ldap openssl
+apk add --no-cache postfix gettext sqlite postfix-sqlite postfix-ldap openssl cyrus-sasl-login
 (
     mkdir -p /etc/ssl/postfix
     cd /etc/ssl/postfix


### PR DESCRIPTION
This pull request adds the `cyrus-sasl-login` package to the postfix installation. This package is required for certain authentication methods in postfix.

https://github.com/NethServer/dev/issues/6926

side note for the testing

I did differently to test my code

- create directly an account to outlook.com with credential
- install a mail server
- force to use login instead of plain authentication with the custom template
- install roundcubemail
- create a default relay rule to send by outlook.com
- send an email to foo@domain.com with roundcubemail
- you get  this error and you cannot authenticate to outlook.com
`May 21 09:26:17 mail postfix/smtp[69385]: 7AE9D18016D01: to=<foo@domain.com>, relay=smtp-mail.outlook.com[52.98.243.6]:587, delay=0.4, delays=0.34/0/0.06/0, dsn=4.7.0, status=deferred (SASL authentication failed; cannot authenticate to server smtp-mail.outlook.com[52.98.243.6]: no mechanism available)`
- upgrade the mail server to this build
- send an email to foo@domain.com with roundcubemail
- you get an error message different that the policy of outlook forbid to send an email with the identity of another
`May 21 09:28:26 mail postfix/smtp[70233]: 0020D1801FDC1: to=<foo@domain.com>, relay=smtp-mail.outlook.com[52.98.252.246]:587, delay=1.9, delays=1.2/0.02/0.35/0.34, dsn=5.2.252, status=bounced (host smtp-mail.outlook.com[52.98.252.246] said: 554 5.2.252 SendAsDenied; foo@outlook.com not allowed to send as administrator@mail.sdl.nethserver.net; STOREDRV.Submission.Exception:SendAsDeniedException.MapiExceptionSendAsDenied; Failed to process message due to a permanent exception with message [BeginDiagnosticData]Cannot submit message. 1.84300:0A000000, 1.84300:0A000000, 1.84300:0E000000, 1.84300:32000000, 1.116652:E71C0000, 1.81836:36020000, 0.117068:0B000000, 1.79180:0A000000, 1.79180:0A000000, 1.79180:0E000000, 1.79180:32000000, 1.79180:FA000000, 0.73100:18000000, 0.38698:05000780, 1.41134:87000000, 1.41134:47000000, 0.37692:87000000, 0.37948:87000000, 5.33852:00000000534D545000000100, 7.36354:010000000000010901000000, 4.56248:DC040000, 7.40748:010000000000010B04000000, 7.57132:00000000000`