### PR TITLE
Add BCC functionality to relay rule configuration

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -103,7 +103,8 @@
         "report-queue-status": "List deferred messages in postfix queue",
         "flush-postfix-queue": "Flush Postfix queue",
         "get-queue-settings": "Get queue settings",
-        "set-queue-settings": "Set queue settings"
+        "set-queue-settings": "Set queue settings",
+        "set-always-bcc": "Set always BCC"
     },
     "error": {
         "error": "Error",
@@ -409,7 +410,12 @@
             "networks_tooltip": "Enter the IP addresses of legacy devices that need to send email messages without SMTP authentication. IPs listed here are exempt from authentication requirements.",
             "enforce_sender_login_match": "Enforce sender/login match",
             "enforce_sender_login_match_tooltip": "The mail sender address must match the SMTP/AUTH login name. Enable this check to avoid the unauthorized use of email addresses and the sender address spoofing.",
-            "save": "Save"
+            "save": "Save",
+            "bcc": "Always BCC address",
+            "bcc_string_lte": "Invalid email format",
+            "is_bcc_enabled": "Always BCC",
+            "bcc_placeholder":  "Eg. user@example.com",
+            "is_bcc_enabled_tooltips": "Enable this option to receive a blind carbon copy of all messages sent through this server."
         },
         "error": {
             "address_error": "Name resolution error",

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -414,7 +414,7 @@
             "bcc": "Always BCC address",
             "bcc_string_lte": "Invalid email format",
             "is_bcc_enabled": "Always BCC",
-            "bcc_placeholder":  "Eg. user@example.com",
+            "bcc_placeholder":  "e.g. user@example.com",
             "is_bcc_enabled_tooltips": "Enable this option to receive a blind carbon copy of all messages sent through this server."
         },
         "error": {

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -415,7 +415,7 @@
             "bcc_string_lte": "Invalid email format",
             "is_bcc_enabled": "Always BCC",
             "bcc_placeholder":  "e.g. user@example.com",
-            "is_bcc_enabled_tooltips": "Enable this option to receive a blind carbon copy of all messages sent through this server."
+            "is_bcc_enabled_tooltips": "When enabled, the specified address will receive a copy of every message sent or received through this server. This setting is useful for mail archiving solutions."
         },
         "error": {
             "address_error": "Name resolution error",


### PR DESCRIPTION
This pull request adds the ability to configure a blind carbon copy (BCC) email address for all messages sent through a relay rule. The BCC address can be specified in the relay rule configuration and will receive a copy of every message sent through the rule. This feature enhances the flexibility and control of email forwarding and archiving.

https://github.com/NethServer/dev/issues/6936

![Capture d’écran du 2024-05-28 10-29-07](https://github.com/NethServer/ns8-mail/assets/3164851/7e92b1cb-e648-4fed-a895-1fa38ed53018)
![Capture d’écran du 2024-05-28 10-29-13](https://github.com/NethServer/ns8-mail/assets/3164851/6f9d41ad-4028-49fa-8a34-8dda9f12eca2)
![Capture d’écran du 2024-05-28 10-29-20](https://github.com/NethServer/ns8-mail/assets/3164851/11d6ccc6-7118-40e4-a136-aad4a04ae0ff)
![Capture d’écran du 2024-05-28 10-30-16](https://github.com/NethServer/ns8-mail/assets/3164851/c794c560-d65a-448d-b364-1e634ceb83bb)
![Capture d’écran du 2024-05-28 10-38-19](https://github.com/NethServer/ns8-mail/assets/3164851/f29c1975-8160-4634-a270-9dfddee4f3d9)

