### PR TITLE
Add Always BCC functionality to import module

### DIFF
--- a/imageroot/actions/import-module/48import_always_bcc
+++ b/imageroot/actions/import-module/48import_always_bcc
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import sys
+import json
+import agent
+
+# Global stdout redirection:
+sys.stdout = sys.stderr
+
+# Import config printjson postfix output:
+print(agent.SD_INFO + "Importing Always BCC Address...", file=sys.stderr)
+jpostfix = json.load(open('postfix.json'))
+
+# Set the POSTFIX_ALWAYS_BCC env variable
+AlwaysBccStatus = jpostfix['props'].get('AlwaysBccStatus') == 'enabled'
+AlwaysBccAddress = jpostfix['props'].get('AlwaysBccAddress')
+if AlwaysBccStatus:
+    # Set the POSTFIX_ALWAYS_BCC env variable
+    # postfix will reloaded later in the import scripts
+    agent.set_env('POSTFIX_ALWAYS_BCC', AlwaysBccAddress)


### PR DESCRIPTION
This pull request adds the functionality to import the Always BCC address in the import module. The `48import_always_bcc` file contains the necessary code to set the `POSTFIX_ALWAYS_BCC` environment variable based on the configuration in the `postfix.json` file. This allows for the configuration of the Always BCC address in the import process.

https://github.com/NethServer/dev/issues/6936