### PR TITLE
Update ownership of dkim_dir to rspamd user and group

### DIFF
--- a/rspamd/entrypoint.sh
+++ b/rspamd/entrypoint.sh
@@ -19,7 +19,7 @@ if [ $# -eq 0 ]; then
         mkdir -v -m 0750 "${dkim_dir}"
         echo "Generating DKIM signing key. Add the following TXT record to DNS domains:"
         rspamadm dkim_keygen -s "${RSPAMD_dkim_selector:?}" -b 2048 -k "${dkim_dir}/${RSPAMD_dkim_selector}.key" | tee "${dkim_dir}/${RSPAMD_dkim_selector}.txt"
-        chgrp -cR rspamd "${dkim_dir}"
+        chown -cR rspamd:rspamd "${dkim_dir}"
     fi
 
     su -s /bin/ash - redis -c "exec /usr/bin/redis-server /etc/redis-persistent.conf" </dev/null &


### PR DESCRIPTION
This pull request updates the ownership of the `dkim_dir` directory to the `rspamd` user and group. Previously, the ownership was set to `rspamd` group only. This change ensures that both the user and group have the correct ownership.