### PR TITLE
Fix validate-output.json

### DIFF
--- a/imageroot/actions/report-queue-status/validate-output.json
+++ b/imageroot/actions/report-queue-status/validate-output.json
@@ -66,12 +66,7 @@
                 ],
                 "properties": {
                     "queue_name": {
-                        "type": "string",
-                        "enum": [
-                            "deferred",
-                            "hold",
-                            "active"
-                        ]
+                        "type": "string"
                     },
                     "queue_id": {
                         "type": "string"


### PR DESCRIPTION
The queue name has many possible values. Only "deferred" is handled at UI level, so we can relax the validator and accept any string.

In some cases the "incoming" value is returned by Postfix, and the validation breaks.