### PR TITLE
Update placeholder for bypass rule input field

### DIFF
--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -328,7 +328,8 @@
         "create_bypass_rule_for": "Create bypass rule for {value}",
         "bypass_rule_is_going_to_be_deleted": "Bypass rule for {value} is going to be deleted...",
         "delete_bypass_rule_for": "Delete bypass rule for {value}",
-        "bypass_rule_already_exists": "This bypass rule already exists"
+        "bypass_rule_already_exists": "This bypass rule already exists",
+        "placeholder_bypass_rule": "E.g. {value}"
     },
     "settings_mailboxes": {
         "title": "Mailboxes settings",

--- a/ui/src/components/CreateBypassRuleModal.vue
+++ b/ui/src/components/CreateBypassRuleModal.vue
@@ -139,13 +139,21 @@ export default {
     valuePlaceholder() {
       switch (this.type) {
         case "email":
-          return "john.doe@example.org";
+          return this.$t("filter_bypass_rules.placeholder_bypass_rule", {
+            value: "john.doe@example.org",
+          });
         case "domain":
-          return "example.org";
+          return this.$t("filter_bypass_rules.placeholder_bypass_rule", {
+            value: "example.org",
+          });
         case "ip":
-          return "192.168.5.123";
+          return this.$t("filter_bypass_rules.placeholder_bypass_rule", {
+            value: "192.168.5.123",
+          });
         case "cidr":
-          return "192.168.5.0/24";
+          return this.$t("filter_bypass_rules.placeholder_bypass_rule", {
+            value: "192.168.5.0/24",
+          });
         default:
           return "";
       }


### PR DESCRIPTION
This pull request updates the placeholder for the bypass rule input field in the CreateBypassRuleModal component. The placeholder now includes an example value for each type of rule (email, domain, IP, and CIDR). This change improves the user experience by providing clear examples of valid input for each rule type.

https://github.com/NethServer/dev/issues/6983

we have a translated placeholder

![image](https://github.com/user-attachments/assets/05f852d1-0d97-4b78-b974-ef08140f53c1)
![image](https://github.com/user-attachments/assets/3bf1d298-5089-4284-8c14-6215d4dadc79)
![image](https://github.com/user-attachments/assets/9dd20e9f-42e5-474b-a4da-2f88ab14ce6e)
![image](https://github.com/user-attachments/assets/86b1b98b-7de9-42c1-a613-7a2a09a3c036)
