### PR TITLE
Add history_redis.conf for storing history in Redis

### DIFF
--- a/imageroot/systemd/user/rspamd.service
+++ b/imageroot/systemd/user/rspamd.service
@@ -26,6 +26,7 @@ ExecStart=/usr/bin/podman run \
     --volume=/dev/log:/dev/log \
     ${MAIL_RSPAMD_IMAGE}
 ExecStartPost=/usr/bin/bash -c "while ! exec 3<>/dev/tcp/127.0.0.1/11334 &>/dev/null; do sleep 3 ; done ; printf 'GET /ping\r\n\r\n' >&3"
+ExecStop=/usr/bin/podman exec %N redis-cli -s /run/redis/persistent.sock save
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/rspamd.ctr-id -t 60
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/rspamd.ctr-id
 ExecReload=runagent discover-services

--- a/rspamd/etc/rspamd/local.d/history_redis.conf
+++ b/rspamd/etc/rspamd/local.d/history_redis.conf
@@ -1,0 +1,18 @@
+#
+# History redis -- https://rspamd.com/doc/modules/history_redis.html
+#
+
+# Redis server to store history
+servers = "/run/redis/persistent.sock";
+
+# Default key name
+key_prefix = "rs_historyrspamd{{COMPRESS}}";
+
+# Default rows limit
+nrows = 2000;
+
+# Use zstd compression when storing data in redis
+compress = true;
+
+# subject privacy is off by default
+subject_privacy = false;


### PR DESCRIPTION
This pull request adds a new configuration file, `history_redis.conf`, which is used for storing history in Redis. The file includes settings for the Redis server, key name, rows limit, compression, and subject privacy. This addition enhances the functionality of the software by allowing history to be stored in Redis.

To resolve the issue of dynamic hostnames affecting Redis keys in a containerized environment, we can use the key_prefix set in `/etc/rspamd/modules.d/history_redis.conf`:

`key_prefix = "rs_history{{HOSTNAME}}{{COMPRESS}}";`

we can modify the key_prefix directly by replacing the dynamic `{{HOSTNAME}}` with a static string in our code  `/etc/rspamd/local.d/history_redis.conf`:

`key_prefix = "rs_historyrspamd{{COMPRESS}}";`

This approach removes the dependency on the container’s hostname, ensuring consistent Redis keys like `rs_historyrspamd{{COMPRESS}} `across all environments.

https://github.com/NethServer/dev/issues/6998


to test the persistency :

- verify the dump file  exists on the drive

`ls /var/lib/redis/persistent.rdb`

- check what are the keys inside redis

```
redis-cli -s /run/redis/persistent.sock
 keys *
 1) "rs_historyrspamd_zst"
redis /run/redis/persistent.sock>  LRANGE rs_historyrspamd_zst 0 -1
```