### PR TITLE
Update LDAP configuration variables to use double quotes

### DIFF
--- a/dovecot/usr/local/bin/dovecot-postlogin
+++ b/dovecot/usr/local/bin/dovecot-postlogin
@@ -10,7 +10,13 @@
 set -e
 
 # Import LDAP connection settings
-. /etc/dovecot/ldapconf.sh
+# sourcing the file directly is broken with quotes
+while IFS= read -r line; do
+    if [[ -n "$line" && "$line" != \#* ]]; then
+        # export only if line is not empty and not a comment
+        export "$line"
+    fi
+done < /etc/dovecot/ldapconf.sh
 
 ldap_search () {
     filter="$1"

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -9,27 +9,27 @@
 
 set -e
 
-ldap_schema=${DOVECOT_LDAP_SCHEMA:?}
+ldap_schema="${DOVECOT_LDAP_SCHEMA:?}"
 
 # Export variables for templates
 set -a
 S=\$
-ldap_host=${DOVECOT_LDAP_HOST:?}
-ldap_domain=${DOVECOT_LDAP_DOMAIN:?}
-ldap_port=${DOVECOT_LDAP_PORT:?}
-ldap_base_dn=${DOVECOT_LDAP_BASE:?}
-ldap_bind_dn=${DOVECOT_LDAP_USER}
-ldap_bind_password=${DOVECOT_LDAP_PASS}
+ldap_host="${DOVECOT_LDAP_HOST:?}"
+ldap_domain="${DOVECOT_LDAP_DOMAIN:?}"
+ldap_port="${DOVECOT_LDAP_PORT:?}"
+ldap_base_dn="${DOVECOT_LDAP_BASE:?}"
+ldap_bind_dn="${DOVECOT_LDAP_USER}"
+ldap_bind_password="${DOVECOT_LDAP_PASS}"
 ldap_users_search_filter_clause=
-submission_host=${DOVECOT_SUBMISSION_HOST:?}
-submission_port=${DOVECOT_SUBMISSION_PORT:?}
-login_trusted_networks=${DOVECOT_TRUSTED_NETWORKS:-}
-doveadm_api_key=${DOVECOT_API_KEY:?}
-doveadm_api_port=${DOVECOT_API_PORT:?}
-stats_http_port=${DOVECOT_METRICS_PORT:?}
-tmpl_spam_folder=${DOVECOT_SPAM_FOLDER:-Junk}
-tmpl_spam_subject_prefix=${DOVECOT_SPAM_SUBJECT_PREFIX:-}
-tmpl_trash_folder=${DOVECOT_TRASH_FOLDER:?}
+submission_host="${DOVECOT_SUBMISSION_HOST:?}"
+submission_port="${DOVECOT_SUBMISSION_PORT:?}"
+login_trusted_networks="${DOVECOT_TRUSTED_NETWORKS:-}"
+doveadm_api_key="${DOVECOT_API_KEY:?}"
+doveadm_api_port="${DOVECOT_API_PORT:?}"
+stats_http_port="${DOVECOT_METRICS_PORT:?}"
+tmpl_spam_folder="${DOVECOT_SPAM_FOLDER:-Junk}"
+tmpl_spam_subject_prefix="${DOVECOT_SPAM_SUBJECT_PREFIX:-}"
+tmpl_trash_folder="${DOVECOT_TRASH_FOLDER:?}"
 tmpl_mail_plugins="acl listescape notify mail_log fts fts_flatcurve"
 tmpl_mail_max_userip_connections="${DOVECOT_MAX_USERIP_CONNECTIONS:-20}"
 # Note: value "0" means "unlimited default quota"; value "" (empty string)
@@ -57,7 +57,7 @@ else
     tmpl_sharedseen=":INDEXPVT=~/Maildir/shared/%%n"
 fi
 
-master_users=${DOVECOT_MASTER_USERS}
+master_users="${DOVECOT_MASTER_USERS}"
 set +a
 
 echo "vmail:{plain}${DOVECOT_VMAIL_PASS}::::::" > /etc/dovecot/users


### PR DESCRIPTION
This pull request updates the LDAP configuration variables in the `reload-config` script and `ldapconf.sh` template file to use double quotes. This ensures that the variables are properly expanded and prevents any potential issues with variable substitution.

https://github.com/NethServer/dev/issues/6992

we have find a new error in log when using a remote ldap with a double quote in the password, probably the same with a single quote

```
Aug 20 10:41:51 rl4 dovecot[47297]: imap-login: Login: user=<lucag>, method=PLAIN, rip=10.5.4.1, lip=10.5.4.1, mpid=571, secured, session=<biHGEhsg4MIKBQQB>
Aug 20 10:41:51 rl4 dovecot[47297]: imap-postlogin: Error: /usr/local/bin/dovecot-postlogin: /etc/dovecot/ldapconf.sh: line 12: syntax error: unterminated quoted string
Aug 20 10:41:51 rl4 dovecot[47297]: imap(lucag): Error: Post-login script denied access to user lucag (connection created 5 msecs ago, client created 5 msecs ago: session=biHGEhsg4MIKBQQB, rip=10.5.4.1, auth_pid=557, client-pid=570, client-id=1, post-login script /run/dovecot/imap-postlogin started 3 msecs ago)
Aug 20 10:41:51 rl4 dovecot[47297]: imap-postlogin: Fatal: master: service(imap-postlogin): child 572 returned error 2
```

https://mattermost.nethesis.it/nethesis/pl/7jqtkhkrrjnqmfw8cx7ao5tfuy