### PR TITLE
Relax smtpd_sender_restrictions

### DIFF
--- a/postfix/usr/local/lib/templates/main.cf
+++ b/postfix/usr/local/lib/templates/main.cf
@@ -95,7 +95,6 @@ always_bcc = ${tmpl_always_bcc}
 # Restrictions
 #
 smtpd_sender_restrictions =
-  reject_non_fqdn_sender,
   ${tmpl_reject_authenticated_sender_login_mismatch},
 
 smtpd_relay_restrictions =


### PR DESCRIPTION
Allow SMTP envelope sender addresses without an FQDN, such as "pecbridge-daemon" and similar.

While the RFC requires the address to have an FQDN in the domain part, strictly enforcing this rule does not enhance spam protection. Rspamd’s default scores remain neutral if the FQDN is missing in the `Mail From` SMTP header.

Refs https://github.com/NethServer/dev/issues/6984
