### PR TITLE
Fix event user-domain-changed

### DIFF
--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -15,7 +15,4 @@ event = json.load(sys.stdin)
 if event.get('domain') != os.getenv('POSTFIX_ORIGIN'):
     exit(0)
 
-if 'node_id' in event and str(event['node_id']) != os.getenv('NODE_ID'):
-    exit(0) # ignore event if the source is not in our node
-
 agent.run_helper('systemctl', '--user', '-T', 'try-reload-or-restart', 'dovecot.service', 'postfix.service').check_returncode()

--- a/imageroot/events/user-domain-changed/20configure_ldap
+++ b/imageroot/events/user-domain-changed/20configure_ldap
@@ -15,7 +15,7 @@ event = json.load(sys.stdin)
 if event.get('domain') != os.getenv('POSTFIX_ORIGIN'):
     exit(0)
 
-if 'node' in event and str(event['node']) != os.getenv('NODE_ID'):
+if 'node_id' in event and str(event['node_id']) != os.getenv('NODE_ID'):
     exit(0) # ignore event if the source is not in our node
 
-agent.run_helper('systemctl', '--user', '-T', 'try-reload-or-restart', 'dovecot.service').check_returncode()
+agent.run_helper('systemctl', '--user', '-T', 'try-reload-or-restart', 'dovecot.service', 'postfix.service').check_returncode()

--- a/imageroot/systemd/user/postfix.service
+++ b/imageroot/systemd/user/postfix.service
@@ -28,7 +28,8 @@ ExecStart=/usr/bin/podman run \
     ${MAIL_POSTFIX_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/postfix.ctr-id -t 60
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/postfix.ctr-id
-ExecReload=runagent /usr/bin/podman exec --env=POSTFIX_* %N reload-config
+ExecReload=runagent discover-services
+ExecReload=runagent /usr/bin/podman exec --env-file=discovery.env --env=POSTFIX_* %N reload-config
 PIDFile=%t/postfix.pid
 Type=forking
 SyslogIdentifier=%N


### PR DESCRIPTION
Update the event handling logic to correctly check for 'node_id' instead of 'node' and reload postfix to autodiscover the ldap settings. This change ensures proper event processing based on the correct identifier.

https://github.com/NethServer/dev/issues/7103