### PR TITLE
Set max_message size to 100MB in rspamd options

### DIFF
--- a/rspamd/README.md
+++ b/rspamd/README.md
@@ -35,10 +35,10 @@ Well-known ports
 - `RSPAMD_bypass_score` If undefined (default) bypass rules are applied as
   an accept prefilter. Set to a negative number to turn the rules to ham
   score and run antivirus checks (e.g. `RSPAMD_bypass_score=-5.000`)
-- `RSPAMD_clamavscansize` sets the maximum size (default 20 MB) for
+- `RSPAMD_clamavscansize` sets the maximum size (default 2 MB) for
   email attachments scanned by ClamAV in Rspamd.
   Attachments larger than this value are skipped to optimize performance.
-  
+
 ## Volumes
 
 - `/etc/rspamd/override.d` Rspamd custom configuration

--- a/rspamd/README.md
+++ b/rspamd/README.md
@@ -35,7 +35,10 @@ Well-known ports
 - `RSPAMD_bypass_score` If undefined (default) bypass rules are applied as
   an accept prefilter. Set to a negative number to turn the rules to ham
   score and run antivirus checks (e.g. `RSPAMD_bypass_score=-5.000`)
-
+- `RSPAMD_clamavscansize` sets the maximum size (default 20 MB) for
+  email attachments scanned by ClamAV in Rspamd.
+  Attachments larger than this value are skipped to optimize performance.
+  
 ## Volumes
 
 - `/etc/rspamd/override.d` Rspamd custom configuration

--- a/rspamd/etc/rspamd/local.d/options.inc
+++ b/rspamd/etc/rspamd/local.d/options.inc
@@ -7,3 +7,4 @@ dns {
     retransmits = 5;
     nameserver = ["127.0.0.1:11336:1"]; # local unbound instance
 }
+max_message = 104857600;

--- a/rspamd/usr/local/templates/antivirus.conf.j2
+++ b/rspamd/usr/local/templates/antivirus.conf.j2
@@ -7,6 +7,8 @@ clamav {
     servers = "{= env.clamav_endpoint =}";
 
     action = "reject";
+    # If `max_size` is set, messages > n bytes in size are not scanned
+    max_size = {= env.clamavscansize | default(20000000) =};
 
     scan_mime_parts = false;
 

--- a/rspamd/usr/local/templates/antivirus.conf.j2
+++ b/rspamd/usr/local/templates/antivirus.conf.j2
@@ -8,7 +8,7 @@ clamav {
 
     action = "reject";
     # If `max_size` is set, messages > n bytes in size are not scanned
-    max_size = {= env.clamavscansize | default(20000000) =};
+    max_size = {= env.clamavscansize | default(2000000) =};
 
     scan_mime_parts = false;
 


### PR DESCRIPTION
Configure rspamd to allow a maximum message size of 100MB in the options file.
Configure rspamd to not scan attachment with size > 2 MB (configurable)
Added documentation of the RSPAMD_clamavscansize to rspamd readme

https://github.com/NethServer/dev/issues/7180