### PR TITLE
Disable SMTPUTF8 support in main.cf

### DIFF
--- a/postfix/usr/local/lib/templates/main.cf
+++ b/postfix/usr/local/lib/templates/main.cf
@@ -131,4 +131,9 @@ smtpd_tls_auth_only = yes
 #
 smtpd_milters = ${tmpl_milters}
 
+#
+# SMTPUTF8 support NethServer/dev#7264
+#
+smtputf8_enable = no
+
 ### end of main.cf ###


### PR DESCRIPTION
Disable SMTPUTF8 support in the Postfix configuration to address compatibility issues.

https://github.com/NethServer/dev/issues/7265