### PR TITLE
fix(mailboxes): make ACL subject comparison case-insensitive

### DIFF
--- a/ui/src/components/mailboxes/CreateOrEditPublicMailboxModal.vue
+++ b/ui/src/components/mailboxes/CreateOrEditPublicMailboxModal.vue
@@ -199,7 +199,7 @@ export default {
 
       for (const selectedAclSubject of this.selectedAclSubjects) {
         const subjectFound = this.allAclSubjects.find(
-          (d) => selectedAclSubject === `${d.name}_${d.dtype}`
+          (d) => selectedAclSubject.toLowerCase() === `${d.name}_${d.dtype}`.toLowerCase()
         );
 
         if (subjectFound) {
@@ -208,7 +208,7 @@ export default {
           if (this.isEditing) {
             const aclFound = this.mailbox.acls.find(
               (a) =>
-                selectedAclSubject === `${a.subject.name}_${a.subject.dtype}`
+                selectedAclSubject.toLowerCase() === `${a.subject.name}_${a.subject.dtype}`.toLowerCase()
             );
 
             if (aclFound) {

--- a/ui/src/components/mailboxes/CreateOrEditPublicMailboxModal.vue
+++ b/ui/src/components/mailboxes/CreateOrEditPublicMailboxModal.vue
@@ -542,7 +542,7 @@ export default {
           const aclSubject = a.subject;
 
           const subjectFound = this.allAclSubjectsForUi.find((aui) => {
-            return aui.value === `${aclSubject.name}_${aclSubject.dtype}`;
+            return aui.value.toLowerCase() === `${aclSubject.name}_${aclSubject.dtype}`.toLowerCase();
           });
 
           if (subjectFound) {


### PR DESCRIPTION
Ensure that the ACL subject comparison in the CreateOrEditPublicMailboxModal is case-insensitive for improved usability.

https://github.com/NethServer/dev/issues/7278

We need to compare `name`

```
root@r3-pve ~]# api-cli run module/mail1/list-public-mailboxes | jq
Warning: using user "cluster" credentials from the environment
[
  {
    "mailbox": "toto",
    "acls": [
      {
        "stype": "user",
        "subject": {
          "dtype": "user",
          "name": "natacha",
          "ui_name": "Natacha"
        },
        "rights": {
          "rtype": "ro",
          "values": [
            "write-seen",
            "lookup",
            "read"
          ]
        }
      }
    ]
  },
  {
    "mailbox": "Junk",
    "acls": []
  },
  {
    "mailbox": "postmaster",
    "acls": []
  }
]
```

with 

```
[root@r3-pve ~]# api-cli run module/mail1/list-acl-subjects | jq
Warning: using user "cluster" credentials from the environment
[
  {
    "dtype": "user",
    "name": "alice",
    "ui_name": "Alice Jordan"
  },
  {
    "dtype": "user",
    "name": "administrator",
    "ui_name": "Builtin administrator user"
  },
  {
    "dtype": "group",
    "name": "domain admins",
    "ui_name": "Domain Administrators"
  },
  {
    "dtype": "user",
    "name": "Natacha",
    "ui_name": "Natacha"
  },
  {
    "dtype": "user",
    "name": "stephane",
    "ui_name": "Stephane"
  },
  {
    "dtype": "user",
    "name": "helene",
    "ui_name": "helene"
  }
]
```

