### PR TITLE
fix(acl): normalize user and group names to lowercase in ACL listing

### DIFF
--- a/imageroot/actions/list-acl-subjects/10list_acl_subjects
+++ b/imageroot/actions/list-acl-subjects/10list_acl_subjects
@@ -24,14 +24,14 @@ try:
     for euser in ldapclient.list_users():
         hdest[euser['user']] = {
             'dtype': 'user',
-            'name': euser['user'],
+            'name': euser['user'].lower(),
             'ui_name': euser['display_name'],
         }
 
     for egroup in ldapclient.list_groups():
         hdest[egroup['group']] = {
             'dtype': 'group',
-            'name': egroup['group'],
+            'name': egroup['group'].lower(),
             'ui_name': egroup['description'],
         }
 


### PR DESCRIPTION
Ensure that user and group names are consistently displayed in lowercase in the ACL listing.

https://github.com/NethServer/dev/issues/7278

We need to compare `name` for user and group

```
root@r3-pve ~]# api-cli run module/mail1/list-public-mailboxes | jq
Warning: using user "cluster" credentials from the environment
[
  {
    "mailbox": "toto",
    "acls": [
      {
        "stype": "user",
        "subject": {
          "dtype": "user",
          "name": "natacha",
          "ui_name": "Natacha"
        },
        "rights": {
          "rtype": "ro",
          "values": [
            "write-seen",
            "lookup",
            "read"
          ]
        }
      }
    ]
  },
  {
    "mailbox": "Junk",
    "acls": []
  },
  {
    "mailbox": "postmaster",
    "acls": []
  }
]
```

with 

```
[root@r3-pve ~]# api-cli run module/mail1/list-acl-subjects | jq
Warning: using user "cluster" credentials from the environment
[
  {
    "dtype": "user",
    "name": "alice",
    "ui_name": "Alice Jordan"
  },
  {
    "dtype": "user",
    "name": "administrator",
    "ui_name": "Builtin administrator user"
  },
  {
    "dtype": "group",
    "name": "domain admins",
    "ui_name": "Domain Administrators"
  },
  {
    "dtype": "user",
    "name": "Natacha",
    "ui_name": "Natacha"
  },
  {
    "dtype": "user",
    "name": "stephane",
    "ui_name": "Stephane"
  },
  {
    "dtype": "user",
    "name": "helene",
    "ui_name": "helene"
  }
]
```
