### PR TITLE
feat(dovecot): enable flatcurve substring search in FTS configuration

### DIFF
--- a/dovecot/README.md
+++ b/dovecot/README.md
@@ -61,7 +61,8 @@ Private TCP ports:
   documentation](https://doc.dovecot.org/settings/core/#core_setting-default_process_limit).
   The `default_client_limit` parameter is proportionally set to 10 times this value.
 - `DOVECOT_SHAREDSEEN`, default empty. If set, the SEEN flag of shared folders is stored in a `dovecot.pvt*` index file, for every user
-
+- `DOVECOT_FLATCURVE_SUBSTRING_SEARCH`, default `no` (`yes` to enable). If enabled, allows substring searches (RFC 3501 compliant). However, this requires significant additional storage space. Many users today expect "Google-like" behavior, which is prefix searching, so substring searching is arguably not the modern expected behavior anyway. Therefore, even though it is not strictly RFC compliant, prefix (non-substring) searching is enabled by default.
+  
 ## Logs
 
 The container sends log messages to `syslog`. Increase log verbosity by

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -34,6 +34,7 @@ tmpl_mail_plugins="acl listescape notify mail_log fts fts_flatcurve"
 tmpl_mail_max_userip_connections="${DOVECOT_MAX_USERIP_CONNECTIONS:-20}"
 tmpl_default_process_limit="${DOVECOT_DEFAULT_PROCESS_LIMIT:-400}"
 tmpl_default_client_limit=$(( DOVECOT_DEFAULT_PROCESS_LIMIT * 10 ))
+flatcurve_substring_search="${DOVECOT_FLATCURVE_SUBSTRING_SEARCH:-no}"
 # Note: value "0" means "unlimited default quota"; value "" (empty string)
 # means "quota plugin disabled".
 if [ -n "${DOVECOT_QUOTA_MB}" ]; then

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -197,6 +197,7 @@ plugin {
   fts_decoder = decode2text
   fts_filters = lowercase normalizer-icu stopwords
   fts_filters_en = lowercase english-possessive stopwords
+  fts_flatcurve_substring_search = ${flatcurve_substring_search}
 }
 
 service decode2text {


### PR DESCRIPTION
Add support for flatcurve substring search in the full-text search configuration.


see options
https://doc.dovecot.org/main/core/plugins/fts_flatcurve.html#fts_flatcurve_substring_search

https://github.com/NethServer/dev/issues/7292