### PR TITLE
Add instructions and conditional configuration for Flatcurve Indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ system idle time:
 To reduce the size of the user's mailbox, you may prefer to disable the Flatcurve Indexer plugin.
 
 Edit the module's `state/environment` file by adding the following line:
+
     DOVECOT_FLATCURVE_ENABLED=no
 
 Reload the Dovecot container:

--- a/README.md
+++ b/README.md
@@ -372,6 +372,17 @@ system idle time:
 
     nice doveadm index -A -q '*'
 
+### Disable FTS indexer
+
+To reduce the size of the user's mailbox, you may prefer to disable the Flatcurve Indexer plugin.
+
+Edit the module's `state/environment` file by adding the following line:
+    DOVECOT_FLATCURVE_ENABLED=no
+
+Reload the Dovecot container:
+
+    systemctl --user reload dovecot
+
 ## UI translation
 
 Translated with [Weblate](https://hosted.weblate.org/projects/ns8/).

--- a/dovecot/README.md
+++ b/dovecot/README.md
@@ -66,12 +66,12 @@ Private TCP ports:
   searching, so substring searching is arguably not the modern expected
   behavior anyway. Therefore, even though it is not strictly RFC
   compliant, prefix (non-substring) searching is enabled by default.
-- `DOVECOT_FLATCURVE_ENABLED`, default `yes` (`no` to disable).
-  To disable the Dovecot FTS flatcurve indexer plugin (enabled by default), set it to no.
 
   If enabled, allows substring searches (RFC 3501 compliant). However,
   this requires rebuilding the existing fts-flatcurve indexes with
   significant additional storage space.
+- `DOVECOT_FLATCURVE_ENABLED`, default `yes` (`no` to disable).
+  To disable the Dovecot FTS flatcurve indexer plugin (enabled by default), set it to no.
 
 ## Logs
 

--- a/dovecot/README.md
+++ b/dovecot/README.md
@@ -66,6 +66,8 @@ Private TCP ports:
   searching, so substring searching is arguably not the modern expected
   behavior anyway. Therefore, even though it is not strictly RFC
   compliant, prefix (non-substring) searching is enabled by default.
+- `DOVECOT_FLATCURVE_ENABLED`, default `yes` (`no` to disable).
+  To disable the Dovecot FTS flatcurve indexer plugin (enabled by default), set it to no.
 
   If enabled, allows substring searches (RFC 3501 compliant). However,
   this requires rebuilding the existing fts-flatcurve indexes with

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -35,6 +35,8 @@ tmpl_mail_plugins="acl listescape notify mail_log"
 if [ "$flatcurve_enabled" == "yes" ]; then
   tmpl_mail_plugins="$tmpl_mail_plugins fts fts_flatcurve"
   tmpl_enabled_flatcurve='fts = flatcurve'
+else
+  tmpl_enabled_flatcurve='# FTS disabled by DOVECOT_FLATCURVE_ENABLED environment variable'
 fi
 tmpl_mail_max_userip_connections="${DOVECOT_MAX_USERIP_CONNECTIONS:-20}"
 tmpl_default_process_limit="${DOVECOT_DEFAULT_PROCESS_LIMIT:-400}"

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -30,7 +30,12 @@ stats_http_port="${DOVECOT_METRICS_PORT:?}"
 tmpl_spam_folder="${DOVECOT_SPAM_FOLDER:-Junk}"
 tmpl_spam_subject_prefix="${DOVECOT_SPAM_SUBJECT_PREFIX:-}"
 tmpl_trash_folder="${DOVECOT_TRASH_FOLDER:?}"
-tmpl_mail_plugins="acl listescape notify mail_log fts fts_flatcurve"
+flatcurve_enabled="${DOVECOT_FLATCURVE_ENABLED:-yes}"
+tmpl_mail_plugins="acl listescape notify mail_log"
+# Check if flatcurve_enabled is set to yes
+if [ "$flatcurve_enabled" == "yes" ]; then
+  tmpl_mail_plugins="$tmpl_mail_plugins fts fts_flatcurve"
+fi
 tmpl_mail_max_userip_connections="${DOVECOT_MAX_USERIP_CONNECTIONS:-20}"
 tmpl_default_process_limit="${DOVECOT_DEFAULT_PROCESS_LIMIT:-400}"
 tmpl_default_client_limit=$(( DOVECOT_DEFAULT_PROCESS_LIMIT * 10 ))

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -32,9 +32,9 @@ tmpl_spam_subject_prefix="${DOVECOT_SPAM_SUBJECT_PREFIX:-}"
 tmpl_trash_folder="${DOVECOT_TRASH_FOLDER:?}"
 flatcurve_enabled="${DOVECOT_FLATCURVE_ENABLED:-yes}"
 tmpl_mail_plugins="acl listescape notify mail_log"
-# Check if flatcurve_enabled is set to yes
 if [ "$flatcurve_enabled" == "yes" ]; then
   tmpl_mail_plugins="$tmpl_mail_plugins fts fts_flatcurve"
+  tmpl_enabled_flatcurve='fts = flatcurve'
 fi
 tmpl_mail_max_userip_connections="${DOVECOT_MAX_USERIP_CONNECTIONS:-20}"
 tmpl_default_process_limit="${DOVECOT_DEFAULT_PROCESS_LIMIT:-400}"

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -189,7 +189,7 @@ plugin {
 # FTS (Full Text Search)
 #
 plugin {
-  fts = flatcurve
+  ${tmpl_enabled_flatcurve}
   fts_autoindex = yes
   # ja needs Requires separate Kuromoji license
   fts_languages = da de en es fi fr it nl no pt ro ru sv tr


### PR DESCRIPTION
Enhance the README with instructions to disable the Flatcurve Indexer and update the reload-config script to conditionally enable Flatcurve plugins based on user preference.

https://github.com/NethServer/dev/issues/7292