### PR TITLE
fix: POSTFIX_MILTERS default value

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -143,6 +143,7 @@ buildah config \
     --volume=/var/spool/postfix \
     --env=TEMPLATES_DIR="/usr/local/lib/templates" \
     --env=SCRIPTS_DIR="/usr/local/lib/scripts" \
+    --env=POSTFIX_MILTERS="inet:127.0.0.1:11332" \
     --entrypoint='["/entrypoint.sh"]' \
     --cmd='' \
     "${container}"

--- a/imageroot/actions/configure-module/20configure
+++ b/imageroot/actions/configure-module/20configure
@@ -27,8 +27,6 @@ with agent.redis_connect() as rdb:
     cluster_network = rdb.get('cluster/network') or ""
 
 if not os.path.exists('rspamd.env'):
-    # First-time configuration defaults
-    agent.set_env('POSTFIX_MILTERS', 'inet:localhost:11332')
     oldmask = os.umask(0o77)
     rspamd_adminpw = genpw()
     with open('rspamd.env', 'w') as fenv:

--- a/imageroot/update-module.d/50reset_milters
+++ b/imageroot/update-module.d/50reset_milters
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+import sys
+
+# Upgrade to new default value for bug NethServer/dev#7343
+if os.getenv('POSTFIX_MILTERS') == 'inet:localhost:11332':
+    agent.unset_env('POSTFIX_MILTERS') # rely on the container default

--- a/postfix/README.md
+++ b/postfix/README.md
@@ -40,7 +40,10 @@ Standard public TCP ports
 - `POSTFIX_LDAP_PASS`, bind password
 - `POSTFIX_LDAP_SCHEMA`, eg `rfc2307`
 - `POSTFIX_LDAP_BASE`, eg `dc=directory,dc=nh`
-- `POSTFIX_MILTERS`, value for Postfix [smtpd_milters](http://www.postfix.org/postconf.5.html#smtpd_milters)
+- `POSTFIX_MILTERS`, value for Postfix
+  [smtpd_milters](http://www.postfix.org/postconf.5.html#smtpd_milters),
+  default is `inet:127.0.0.1:11332`. Set to empty string to completely
+  bypass Rspamd.
 - `POSTFIX_MAXIMAL_QUEUE_LIFETIME`, value for the maximum amount of hours that a message is allowed to stay in a queue (5 days is assumed if value is empty)
 - `POSTFIX_RESTRICTED_SENDER` Empty or `1`. If set, the SMTP/AUTH user
   name can use a restricted set of sender addresses. The set is given by


### PR DESCRIPTION
Set the environment variable POSTFIX_MILTERS=inet:127.0.0.1:11332 in Postfix container to ensure the variable has the default value after a backup restoration.

If the old default value is found in existing installations, the variable is removed from the `environment` file.

Refs NethServer/dev#7343