### PR TITLE
feat: enable FILTER=SIEVE IMAP plugin

### DIFF
--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -176,7 +176,7 @@ protocol lmtp {
 # 90-acls
 #
 protocol imap {
-  mail_plugins = ${S}mail_plugins imap_acl imap_sieve
+  mail_plugins = ${S}mail_plugins imap_acl imap_sieve imap_filter_sieve
 }
 
 plugin {


### PR DESCRIPTION
Enable a vendor-defined IMAP extension called FILTER=SIEVE that allows applying a mail filter (a Sieve script) on a set of messages that match the specified IMAP searching criteria.

Refs NethServer/dev#7230