### PR TITLE
feat(rspamd): Add unbound configuration template for ipv6 status

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -156,6 +156,8 @@ set -e
 apk add --no-cache redis
 apk add --no-cache rspamd rspamd-controller rspamd-proxy rspamd-fuzzy rspamd-client
 apk add --no-cache unbound
+# for envsubst 
+apk add --no-cache gettext
 chown -c root:root /etc/rspamd/local.d/maps.d
 EOF
 buildah add "${container}" rspamd/ /

--- a/rspamd/usr/local/bin/reload-config
+++ b/rspamd/usr/local/bin/reload-config
@@ -12,12 +12,14 @@ set -e
 # Export variables for templates
 set -a
 # the sysctl command is available inside the containers
-unbound_ipv6=$(sysctl -n net.ipv6.conf.all.disable_ipv6)
-if [ "${unbound_ipv6}" -eq 1 ]; then
+ipv6=$(sysctl -n net.ipv6.conf.all.disable_ipv6)
+if [ "${ipv6}" -eq 1 ]; then
     unbound_ipv6="no"
 else
     unbound_ipv6="yes"
 fi
+# stop exporting variables
+set +a
 
 cd /usr/local/templates
 

--- a/rspamd/usr/local/bin/reload-config
+++ b/rspamd/usr/local/bin/reload-config
@@ -9,6 +9,16 @@
 
 set -e
 
+# Export variables for templates
+set -a
+# the sysctl command is available inside the containers
+unbound_ipv6=$(sysctl -n net.ipv6.conf.all.disable_ipv6)
+if [ "${unbound_ipv6}" -eq 1 ]; then
+    unbound_ipv6="no"
+else
+    unbound_ipv6="yes"
+fi
+
 cd /usr/local/templates
 
 rspamadm template actions.conf.j2 > /etc/rspamd/local.d/actions.conf
@@ -16,6 +26,8 @@ rspamadm template antivirus.conf.j2 > /etc/rspamd/local.d/antivirus.conf
 rspamadm template greylist.conf.j2 > /etc/rspamd/local.d/greylist.conf
 rspamadm template multimap.conf.j2 > /etc/rspamd/local.d/multimap.conf
 rspamadm template rspamd.conf.local.j2 > /etc/rspamd/rspamd.conf.local
+
+envsubst >/etc/unbound/unbound.conf < unbound.conf
 
 main_process=$(pgrep 'rspamd: main process' || :)
 if [ -n "${main_process}" ]; then

--- a/rspamd/usr/local/templates/unbound.conf
+++ b/rspamd/usr/local/templates/unbound.conf
@@ -7,7 +7,7 @@ server:
 	outgoing-range: 384
 	outgoing-port-permit: "32768-65535"
 	outgoing-port-avoid: "0-32767"
-	do-ip6: yes
+	do-ip6: ${unbound_ipv6}
 	do-tcp: yes
 	do-daemonize: no
 	prefetch: yes


### PR DESCRIPTION
Introduce a new unbound configuration template and enhance the reload-config script to support IPv6 settings.

Refs https://github.com/NethServer/dev/issues/7402