### PR TITLE
fix(import-module): Shared seen index migration

### DIFF
--- a/imageroot/actions/import-module/35migrate_maildirs
+++ b/imageroot/actions/import-module/35migrate_maildirs
@@ -66,7 +66,7 @@ for entry in *; do
     # Fix paths for shared namespace
     find "${ddest}" -type d -path "${ddest}/Maildir/shared/*@${1}" -print | (
         while read -r shared_entry ; do
-            mv -vf "${shared_entry}" "{shared_entry%%@${1}}" || :
+            mv -vf "${shared_entry}" "${shared_entry%%@${1}}" || :
         done
     )
 


### PR DESCRIPTION
A typo in the migration script prevents the correct migration of Shared Seen flag indexes.

Refs NethServer/dev#7428