### PR TITLE
fix: mixed-case ACL group match

### DIFF
--- a/dovecot/usr/local/bin/dovecot-postlogin
+++ b/dovecot/usr/local/bin/dovecot-postlogin
@@ -48,6 +48,8 @@ if [ -z "${ACL_GROUPS}" ]; then
 
     USERDB_KEYS="${USERDB_KEYS} ACL_GROUPS"
     ACL_GROUPS=$(ldap_search "${filter}" ${attr})
+    # Append the same list of groups in lowercase form for case-insensitive match:
+    ACL_GROUPS="${ACL_GROUPS}${ACL_GROUPS:+,}$(printf "%s\n" "${ACL_GROUPS}" | tr '[A-Z]' '[a-z]')"
     export USERDB_KEYS ACL_GROUPS
 fi
 


### PR DESCRIPTION
Our API normalizes group names to lower-case.

If LDAP returns group names in mixed-case, ensure the folder ACL can match by checking both mixed-case and lower-case.

Refs NethServer/dev#7480