### PR TITLE
Update url of documentation

### DIFF
--- a/ui/public/metadata.json
+++ b/ui/public/metadata.json
@@ -11,7 +11,7 @@
     }
   ],
   "docs": {
-    "documentation_url": "https://github.com/NethServer/ns8-mail",
+    "documentation_url": "https://docs.nethserver.org/projects/ns8/en/latest/mail.html",
     "bug_url": "https://github.com/NethServer/dev",
     "code_url": "https://github.com/NethServer/ns8-mail"
   },


### PR DESCRIPTION
This pull request updates the `documentation_url` in the `ui/public/metadata.json` file to point to the official NethServer documentation site instead of the GitHub repository.

* **Metadata update**:
  * [`ui/public/metadata.json`](diffhunk://#diff-57394ba6289dada95fe587665ef1b86264521bc888ccdaa69d5994e96f1ea77dL14-R14): Changed the `documentation_url` to `https://docs.nethserver.org/projects/ns8/en/latest/mail.html` for better alignment with the official documentation.

https://github.com/NethServer/dev/issues/7399