### PR TITLE
fix: protect spam folder name

### DIFF
--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -49,11 +49,11 @@ last_valid_gid = 101
 
 namespace inbox {
   separator = /
-  mailbox ${tmpl_spam_folder} {
+  mailbox "${tmpl_spam_folder}" {
     special_use = \Junk
     auto = ${tmpl_spam_folder_auto}
   }
-  mailbox ${tmpl_trash_folder} {
+  mailbox "${tmpl_trash_folder}" {
     special_use = \Trash
     auto = subscribe
   }

--- a/imageroot/validator-definitions.json
+++ b/imageroot/validator-definitions.json
@@ -458,7 +458,8 @@
                 "name": {
                     "type": "string",
                     "title": "Folder name",
-                    "minLength": 1
+                    "minLength": 1,
+                    "pattern": "^[^\"]+$"
                 }
             }
         },


### PR DESCRIPTION
- Enclose the spam folder name in double quotes, to allow the usage of the space character.
- Forbid double quotes character in spam folder name.


Refs NethServer/dev#7543