### PR TITLE
fix: limit LDAP queries to certain domains

### DIFF
--- a/postfix/usr/local/lib/templates/laddgroupmembers-ad.cf
+++ b/postfix/usr/local/lib/templates/laddgroupmembers-ad.cf
@@ -13,4 +13,4 @@ query_filter = (&(objectClass=group)(sAMAccountName=%u)(groupType:1.2.840.113556
 result_attribute = sAMAccountName
 special_result_attribute = member
 leaf_result_attribute = sAMAccountName
-domain = ${tmpl_laddgroups_domains}
+domain = ${tmpl_laddgroups_domains} notempty.invalid

--- a/postfix/usr/local/lib/templates/laddgroupmembers-rfc2307.cf
+++ b/postfix/usr/local/lib/templates/laddgroupmembers-rfc2307.cf
@@ -11,4 +11,4 @@ server_port = ${tmpl_ldap_port}
 search_base = ${tmpl_ldap_base}
 query_filter = (&(objectClass=posixGroup)(cn=%u))
 result_attribute = memberUid
-domain = ${tmpl_laddgroups_domains}
+domain = ${tmpl_laddgroups_domains} notempty.invalid

--- a/postfix/usr/local/lib/templates/laddgroups-ad.cf
+++ b/postfix/usr/local/lib/templates/laddgroups-ad.cf
@@ -11,4 +11,4 @@ server_port = ${tmpl_ldap_port}
 search_base = ${tmpl_ldap_base}
 query_filter = (&(objectClass=group)(sAMAccountName=%u)(groupType:1.2.840.113556.1.4.803:=2)(!(isCriticalSystemObject=TRUE)))
 result_attribute = sAMAccountName
-domain = ${tmpl_laddgroups_domains}
+domain = ${tmpl_laddgroups_domains} notempty.invalid

--- a/postfix/usr/local/lib/templates/laddgroups-rfc2307.cf
+++ b/postfix/usr/local/lib/templates/laddgroups-rfc2307.cf
@@ -11,4 +11,4 @@ server_port = ${tmpl_ldap_port}
 search_base = ${tmpl_ldap_base}
 query_filter = (&(objectClass=posixGroup)(cn=%u))
 result_attribute = cn
-domain = ${tmpl_laddgroups_domains}
+domain = ${tmpl_laddgroups_domains} notempty.invalid

--- a/postfix/usr/local/lib/templates/laddusers-ad.cf
+++ b/postfix/usr/local/lib/templates/laddusers-ad.cf
@@ -11,4 +11,4 @@ server_port = ${tmpl_ldap_port}
 search_base = ${tmpl_ldap_base}
 query_filter = (&(objectClass=user)(objectCategory=person)(sAMAccountName=%u))
 result_attribute = sAMAccountName
-domain = ${tmpl_laddusers_domains}
+domain = ${tmpl_laddusers_domains} notempty.invalid

--- a/postfix/usr/local/lib/templates/laddusers-rfc2307.cf
+++ b/postfix/usr/local/lib/templates/laddusers-rfc2307.cf
@@ -11,4 +11,4 @@ server_port = ${tmpl_ldap_port}
 search_base = ${tmpl_ldap_base}
 query_filter = (&(objectClass=posixAccount)(objectClass=inetOrgPerson)(uid=%u))
 result_attribute = uid
-domain = ${tmpl_laddusers_domains}
+domain = ${tmpl_laddusers_domains} notempty.invalid


### PR DESCRIPTION
If no domain with addusers flag exists, ensure LDAP query based on the domain is skipped. We define a special "notempty.invalid" domain name to ensure that the domain filter is always non-empty.

The same workaround is implemented for the addgroups flag. Ensure LDAP queries based on the domain are skipped if no domain has addgroups flag.

Refs NethServer/dev#7385