### PR TITLE
Update to rspamd 4.x and add configuration options

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -150,14 +150,12 @@ images+=("${repobase}/${reponame}")
 # Rspamd additional image
 #
 reponame="mail-rspamd"
-container=$(buildah from docker.io/library/alpine:3.21.7)
+container=$(buildah from docker.io/library/alpine:edge)
 buildah run "${container}" /bin/sh <<EOF
 set -e
-# Add Alpine edge community repo for rspamd 4.x
-echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 # Software installation order is important to preserve uid and gid allocation:
 apk add --no-cache redis
-apk add --no-cache rspamd@edge rspamd-controller@edge rspamd-proxy@edge rspamd-fuzzy@edge rspamd-client@edge
+apk add --no-cache rspamd rspamd-controller rspamd-proxy rspamd-fuzzy rspamd-client
 apk add --no-cache unbound
 # for envsubst 
 apk add --no-cache gettext

--- a/build-images.sh
+++ b/build-images.sh
@@ -153,9 +153,11 @@ reponame="mail-rspamd"
 container=$(buildah from docker.io/library/alpine:3.21.7)
 buildah run "${container}" /bin/sh <<EOF
 set -e
+# Add Alpine edge community repo for rspamd 4.x
+echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 # Software installation order is important to preserve uid and gid allocation:
 apk add --no-cache redis
-apk add --no-cache rspamd rspamd-controller rspamd-proxy rspamd-fuzzy rspamd-client
+apk add --no-cache rspamd@edge rspamd-controller@edge rspamd-proxy@edge rspamd-fuzzy@edge rspamd-client@edge
 apk add --no-cache unbound
 # for envsubst 
 apk add --no-cache gettext

--- a/rspamd/etc/rspamd/local.d/milter_headers.conf
+++ b/rspamd/etc/rspamd/local.d/milter_headers.conf
@@ -13,7 +13,7 @@ custom {
     # value of their spam indicator
     x_rspamd_flag_threshold = <<EOD
 return function(task, common_meta)
-    local flag_threshold = rspamd_config:get_metric_action('add header');
+    local flag_threshold = rspamd_config:get_metric_action('add_header');
     return nil, {["X-Rspamd-Flag-Threshold"] = tostring(flag_threshold)}, {["X-Rspamd-Flag-Threshold"] = 0}, {};
 end
 EOD;

--- a/rspamd/etc/rspamd/local.d/options.inc
+++ b/rspamd/etc/rspamd/local.d/options.inc
@@ -1,6 +1,11 @@
 #
 # Options -- https://rspamd.com/doc/configuration/options.html
 #
+
+# rspamd 4.x: content URLs (PDF, etc.) are included by default in task:get_urls()
+# Disable to preserve old behavior and avoid unintended RBL hits
+include_content_urls = false;
+
 dns {
     timeout = 1s;
     sockets = 16;


### PR DESCRIPTION
Upgrade rspamd to version 4.x using the Alpine edge community repository. Correct the function call in the milter headers configuration. Introduce an option to disable content URLs in rspamd 4.x to maintain previous behavior.

## Configuration compatibility review (rspamd 4.0)

### Static files (`local.d/`)

| File | Status | Note |
|---|---|---|
| `options.inc` | ✅ fixed | `include_content_urls = false` added |
| `milter_headers.conf` | ✅ fixed | `'add_header'` (underscore) |
| `worker-controller.inc` | ✅ OK | `ssl = true` not used, no migration needed |
| `classifier-bayes.conf` | ✅ OK | Single Redis server, no Jump Hash → Ring Hash migration needed |
| `dkim_signing.conf` | ✅ OK | Standard DKIM config, RFC conformance in 4.x has no impact here |
| `history_redis.conf` | ✅ OK | `{{COMPRESS}}` is an internal rspamd substitution, not a template |
| `logging.inc` | ✅ OK | |
| `mx_check.conf` | ✅ OK | |
| `redis.conf` | ✅ OK | |

### Templates (`.j2`)

| File | Status | Note |
|---|---|---|
| `actions.conf.j2` | ✅ OK | Already uses `add_header` (underscore) |
| `greylist.conf.j2` | ✅ OK | |
| `antivirus.conf.j2` | ✅ OK | |
| `rspamd.conf.local.j2` | ✅ OK | Settings flow still compatible with `symbols_enabled` in 4.x |
| `multimap.conf.j2` | ✅ OK | `prefilter`/`action` unchanged in 4.x |
| `rbl.conf.j2` | ✅ OK | Spamhaus DQS still valid; `include_content_urls = false` protects URL checks |
| `rbl_group.conf.j2` | ✅ OK | |

### Infrastructure

| File | Status | Note |
|---|---|---|
| `entrypoint.sh` | ✅ OK | `rspamadm dkim_keygen` still valid in 4.x |
| `reload-config` | ✅ OK | `rspamadm template` still supported in 4.x |
| `redis-persistent.conf` | ✅ OK | |
| `redis-volatile.conf` | ✅ OK | |
| `unbound.conf` | ✅ OK | |