### PR TITLE
fix: restore fails if spam_folder is empty

### DIFF
--- a/imageroot/actions/restore-module/70configure_module
+++ b/imageroot/actions/restore-module/70configure_module
@@ -19,14 +19,12 @@ configure_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='conf
 })
 agent.assert_exp(configure_retval['exit_code'] == 0, "The configure-module subtask failed!")
 
+spam_folder_env = renv.get("DOVECOT_SPAM_FOLDER", "")
 settings_retval = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='set-mailbox-settings', data={
     "spam_retention": {
         "value": int(renv.get("DOVECOT_SPAM_RETENTION", "15"))
     },
-    "spam_folder": {
-        "enabled": bool(renv.get("DOVECOT_SPAM_FOLDER", "")),
-        "name": renv.get("DOVECOT_SPAM_FOLDER", "Junk")
-    },
+    "spam_folder": {"enabled": True, "name": spam_folder_env} if spam_folder_env else {"enabled": False},
     "spam_prefix": {
         "enabled": bool(renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "")),
         "prefix": renv.get("DOVECOT_SPAM_SUBJECT_PREFIX", "")

--- a/ui/public/i18n/en/translation.json
+++ b/ui/public/i18n/en/translation.json
@@ -375,6 +375,7 @@
         "move_spam_but_no_folder": "If \"Move spam to junk folder\" is enabled, junk folder name is required",
         "quota": "Quota",
         "spam": "Spam",
+        "junk_folder_placeholder": "e.g. Junk",
         "shared_mailboxes": "Shared mailboxes",
         "sharedseen": "Shared seen",
         "sharedseen_explanation_tooltips": "If enabled, a message is marked seen (read) by the first user that opens it, with effect for everyone else sharing the same mailbox"

--- a/ui/src/views/settings/SettingsMailboxes.vue
+++ b/ui/src/views/settings/SettingsMailboxes.vue
@@ -203,6 +203,7 @@
                   <NsTextInput
                     v-show="spamFolder.enabled"
                     v-model.trim="spamFolder.name"
+                    :placeholder="$t('settings_mailboxes.junk_folder_placeholder')"
                     :label="$t('settings_mailboxes.junk_folder_name')"
                     :invalid-message="$t(error.spam_folder)"
                     :disabled="loading.setMailboxSettings"


### PR DESCRIPTION
## Problem

When the mail module is installed without enabling the Junk folder, `DOVECOT_SPAM_FOLDER` is stored as an empty string.

During restore, `70configure_module` calls `set-mailbox-settings` and passes `spam_folder.name = ""`.

The JSON schema enforces `minLength: 1` on `name`. This causes a validation error that aborts the restore entirely.

## Root cause

The code used `.get("DOVECOT_SPAM_FOLDER", "Junk")` expecting to fall back to `"Junk"` when the folder is disabled. But the fallback only triggers when the key is **absent**. When the key exists with an empty value, Python returns `""` instead.

## Fix

I read `DOVECOT_SPAM_FOLDER` into a variable first.

If it is empty, I send `{"enabled": false}` with no `name` field. If it has a value, I send `{"enabled": true, "name": <value>}`.

This matches exactly what the schema expects in both cases.

## References

Fixes https://github.com/NethServer/dev/issues/7980