### PR TITLE
Auto-create Sent and Drafts default folders

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -114,6 +114,8 @@ buildah config \
     --env=DOVECOT_SPAM_FOLDER=Junk \
     --env=DOVECOT_SPAM_SUBJECT_PREFIX= \
     --env=DOVECOT_TRASH_FOLDER=Trash \
+    --env=DOVECOT_SENT_FOLDER=Sent \
+    --env=DOVECOT_DRAFTS_FOLDER=Drafts \
     --env=DOVECOT_MAX_USERIP_CONNECTIONS=20 \
     --env=DOVECOT_DEFAULT_PROCESS_LIMIT=400 \
     --env=LD_PRELOAD=/usr/lib/libmimalloc.so.2 \

--- a/dovecot/README.md
+++ b/dovecot/README.md
@@ -54,6 +54,8 @@ Private TCP ports:
 - `DOVECOT_SPAM_SUBJECT_PREFIX`, default empty. If set, the string is prefixed to the message `Subject:` header.
 - `DOVECOT_SPAMT_PASS`, password for Rspamd API, required for ham/spam training
 - `DOVECOT_TRASH_FOLDER`, default `Trash`. Mailbox folder name where messages are moved when they are deleted.
+- `DOVECOT_SENT_FOLDER`, default `Sent`. Mailbox folder name for sent messages, created and subscribed at first mailbox access.
+- `DOVECOT_DRAFTS_FOLDER`, default `Drafts`. Mailbox folder name for draft messages, created and subscribed at first mailbox access.
 - `DOVECOT_MAX_USERIP_CONNECTIONS`, default `20`. Set dovecot `mail_max_userip_connections` configuration parameter. This limit is raised 5 times for connections coming from trusted networks
 - `DOVECOT_DEFAULT_PROCESS_LIMIT`, default `400`. Set dovecot
   `default_process_limit` parameter. The value 400 is four times Dovecot's

--- a/dovecot/usr/local/bin/reload-config
+++ b/dovecot/usr/local/bin/reload-config
@@ -30,6 +30,8 @@ stats_http_port="${DOVECOT_METRICS_PORT:?}"
 tmpl_spam_folder="${DOVECOT_SPAM_FOLDER:-Junk}"
 tmpl_spam_subject_prefix="${DOVECOT_SPAM_SUBJECT_PREFIX:-}"
 tmpl_trash_folder="${DOVECOT_TRASH_FOLDER:?}"
+tmpl_sent_folder="${DOVECOT_SENT_FOLDER:-Sent}"
+tmpl_drafts_folder="${DOVECOT_DRAFTS_FOLDER:-Drafts}"
 flatcurve_enabled="${DOVECOT_FLATCURVE_ENABLED:-yes}"
 tmpl_mail_plugins="acl listescape notify mail_log"
 if [ "$flatcurve_enabled" == "yes" ]; then

--- a/dovecot/usr/local/lib/templates/local.conf
+++ b/dovecot/usr/local/lib/templates/local.conf
@@ -57,6 +57,14 @@ namespace inbox {
     special_use = \Trash
     auto = subscribe
   }
+  mailbox "${tmpl_drafts_folder}" {
+    special_use = \Drafts
+    auto = subscribe
+  }
+  mailbox "${tmpl_sent_folder}" {
+    special_use = \Sent
+    auto = subscribe
+  }
 }
 namespace SHARED_USERS {
   location = maildir:/var/lib/vmail/%%n/Maildir${tmpl_sharedseen}

--- a/tests/20__dovecot.robot
+++ b/tests/20__dovecot.robot
@@ -56,6 +56,12 @@ LDAP Login checks
     IMAP login bad credentials
     AD user credentials are bad with LDAP
 
+Default mailbox folders are created
+    [Documentation]    Sent/Drafts/Junk/Trash must exist and be subscribed at first
+    ...                mailbox access, without any message being sent (issue dev#8104).
+    Wait Until Keyword Succeeds    20 seconds    1 second
+    ...    Default folders exist and are subscribed    u1
+
 Switch to AD user domain
     Run task     module/${MID}/configure-module
     ...          {"hostname":"mail.domain.test","user_domain":"ad.dom.test","mail_domain":"domain.test"}
@@ -67,6 +73,19 @@ Active Directory Login checks
     LDAP user credentials are bad with AD
 
 *** Keywords ***
+Default folders exist and are subscribed
+    [Arguments]    ${user}
+    # Force namespace init so auto=subscribe mailboxes are materialized
+    Execute Command    timeout ${curl_timeout} curl -s -f -u u1:Nethesis,1234 imap://127.0.0.1 || true
+    ${out}  ${err}  ${rc} =    Execute Command
+    ...    runagent -m ${MID} podman exec dovecot doveadm mailbox list -s -u ${user}
+    ...    return_rc=True    return_stderr=True
+    Should Be Equal As Integers    ${rc}    0
+    Should Contain    ${out}    Drafts
+    Should Contain    ${out}    Sent
+    Should Contain    ${out}    Junk
+    Should Contain    ${out}    Trash
+
 LDAP user credentials are bad with AD
     [Documentation]    When bad credentials are issued the server replies with
     ...                a few seconds of delay.


### PR DESCRIPTION
Dovecot only auto-created `Junk` and `Trash` in the `inbox` namespace. `Sent` and `Drafts` were never created by the server, so they appeared only after the user sent a first message. When an IMAP client is configured before those folders exist, it can create duplicates (e.g. Italian Outlook creates `Posta inviata` instead of `Sent`) or fail to copy sent messages.

This declares `Sent` and `Drafts` as auto-created and subscribed mailboxes with their `special_use` flags (RFC 6154), so they exist at first mailbox access regardless of the client or webmail (Roundcube, WebTop, SOGo, IMAP clients).

Changes, mirroring the existing `DOVECOT_TRASH_FOLDER` pattern:
- `local.conf`: two new `mailbox` blocks in the `inbox` namespace, `auto = subscribe`, `special_use = \Sent` / `\Drafts`.
- `reload-config`: `tmpl_sent_folder` / `tmpl_drafts_folder` template variables (defaults `Sent` / `Drafts`).
- `build-images.sh`: `DOVECOT_SENT_FOLDER` / `DOVECOT_DRAFTS_FOLDER` build-time defaults.
- `README.md`: documented both variables.

Existing users get the folders at next mailbox access, no migration needed.

Ref: NethServer/dev#8104

This supersedes NethServer/ns8-roundcubemail#116, which only covered Roundcube at webmail login.