### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/clamav-unofficial-sigs.service
+++ b/imageroot/systemd/user/clamav-unofficial-sigs.service
@@ -6,5 +6,5 @@ After=clamav.service
 [Service]
 Type=oneshot
 ExecStart=podman exec clamav download-sigs cus -s
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%N

--- a/imageroot/systemd/user/clamav.service
+++ b/imageroot/systemd/user/clamav.service
@@ -5,8 +5,8 @@ Description=ClamAV anti-virus
 Environment=PODMAN_SYSTEMD_UNIT=%n
 Environment=CLAMAV_CUSCFG_VOLUME_FLAGS=O
 Environment=CLAMAV_CUS_RATING=MEDIUM
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/clamav.pid %t/clamav.ctr-id
 ExecStart=/usr/bin/podman run \

--- a/imageroot/systemd/user/dhgen.service
+++ b/imageroot/systemd/user/dhgen.service
@@ -5,5 +5,5 @@ Description=Diffie-Hellman group generator
 Type=oneshot
 ExecStart=runagent generate-dhpem
 ExecStart=-systemctl --user reload postfix.service dovecot.service
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%N

--- a/imageroot/systemd/user/dovecot.service
+++ b/imageroot/systemd/user/dovecot.service
@@ -5,8 +5,8 @@ After=get-certificate.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/dovecot.pid %t/dovecot.ctr-id
 ExecStartPre=runagent discover-services

--- a/imageroot/systemd/user/freshclam.service
+++ b/imageroot/systemd/user/freshclam.service
@@ -6,5 +6,5 @@ After=clamav.service
 [Service]
 Type=oneshot
 ExecStart=podman exec clamav download-sigs freshclam
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%N

--- a/imageroot/systemd/user/get-certificate.service
+++ b/imageroot/systemd/user/get-certificate.service
@@ -4,8 +4,8 @@ Description=Get TLS certificate from Traefik
 [Service]
 Type=oneshot
 SuccessExitStatus=0,3
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 SyslogIdentifier=%N
 ExecStart=-mkdir -vp tls-certs
 ExecStart=-runagent get-certificate --cert-file=tls-certs/server.pem --key-file=tls-certs/server.key $POSTFIX_HOSTNAME

--- a/imageroot/systemd/user/postfix.service
+++ b/imageroot/systemd/user/postfix.service
@@ -5,8 +5,8 @@ Wants=get-certificate.service
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/postfix.pid %t/postfix.ctr-id
 ExecStartPre=/bin/mkdir -vp pcdb

--- a/imageroot/systemd/user/rspamd.service
+++ b/imageroot/systemd/user/rspamd.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Rspamd mail filter
-ConditionPathExists=%S/state/rspamd.env
+ConditionPathExists=%E/state/rspamd.env
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
-WorkingDirectory=%S/state
+EnvironmentFile=%E/state/environment
+WorkingDirectory=%E/state
 Restart=always
 ExecStartPre=/bin/rm -f %t/rspamd.pid %t/rspamd.ctr-id
 ExecStartPre=runagent discover-services

--- a/imageroot/systemd/user/spam-expunge.service
+++ b/imageroot/systemd/user/spam-expunge.service
@@ -6,5 +6,5 @@ Requisite=dovecot.service
 [Service]
 Type=oneshot
 ExecStart=podman exec dovecot spam-expunge
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%N


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host