### PR TITLE
fix(list-destinations): lower-case user and group names

### DIFF
--- a/imageroot/actions/list-destinations/10list_destinations
+++ b/imageroot/actions/list-destinations/10list_destinations
@@ -24,14 +24,14 @@ try:
     for euser in ldapclient.list_users():
         hdest[euser['user']] = {
             'dtype': 'user',
-            'name': euser['user'],
+            'name': euser['user'].lower(),
             'ui_name': euser['display_name'],
         }
 
     for egroup in ldapclient.list_groups():
         hdest[egroup['group']] = {
             'dtype': 'group',
-            'name': egroup['group'],
+            'name': egroup['group'].lower(),
             'ui_name': egroup['description'],
         }
 

--- a/tests/40__api/20__addresses.robot
+++ b/tests/40__api/20__addresses.robot
@@ -16,6 +16,23 @@ Check users and groups addresses are in the address list
     Should Contain    ${laddresses}[addresses]    ${ou1}
     Should Contain    ${laddresses}[addresses]    ${og1}
 
+Check mixed-case AD/LDAP user and group destinations are lower-cased
+    ${ldest} =    Run task    module/${MID}/list-destinations    ""
+    ${user_found} =    Set Variable    ${FALSE}
+    ${group_found} =    Set Variable    ${FALSE}
+    FOR    ${odest}    IN    @{ldest}
+        IF    "${odest}[dtype]" == "user" and "${odest.get('ui_name', '')}" == "Mixed Case User"
+            Should Be Equal    ${odest}[name]    mixedcaseuser
+            ${user_found} =    Set Variable    ${TRUE}
+        END
+        IF    "${odest}[dtype]" == "group" and "${odest.get('ui_name', '')}" == "Mixed Case Group"
+            Should Be Equal    ${odest}[name]    mixedcasegroup
+            ${group_found} =    Set Variable    ${TRUE}
+        END
+    END
+    Should Be True    ${user_found}
+    Should Be True    ${group_found}
+
 Add a user address alias
     Run task    module/${MID}/add-address    {"atype":"domain","local":"u1-alias","domain":"${test_domain}","destinations":[{"dtype":"user","name":"u1"}]}
 
@@ -25,6 +42,29 @@ Add invalid address
 
 Add a group address alias
     Run task    module/${MID}/add-address    {"atype":"domain","local":"g1-alias","domain":"${test_domain}","destinations":[{"dtype":"group","name":"g1"}]}
+
+Add a mixed-case user address alias
+    Run task    module/${MID}/add-address    {"atype":"domain","local":"mixeduser-alias","domain":"${test_domain}","destinations":[{"dtype":"user","name":"MixedCaseUser"}]}
+
+Check the mixed-case user destination matches list-destinations
+    ${laddresses} =    Run task    module/${MID}/list-addresses    ""
+    ${ldest} =    Run task    module/${MID}/list-destinations    ""
+    ${alias_dest_name} =    Set Variable    ${NONE}
+    FOR    ${oaddr}    IN    @{laddresses}[addresses]
+        IF    "${oaddr}[local]" == "mixeduser-alias"
+            FOR    ${odest}    IN    @{oaddr}[destinations]
+                ${alias_dest_name} =    Set Variable    ${odest}[name]
+            END
+        END
+    END
+    Should Be Equal    ${alias_dest_name}    mixedcaseuser
+    ${dest_match_found} =    Set Variable    ${FALSE}
+    FOR    ${odest}    IN    @{ldest}
+        IF    "${odest}[dtype]" == "user" and "${odest}[name]" == "${alias_dest_name}"
+            ${dest_match_found} =    Set Variable    ${TRUE}
+        END
+    END
+    Should Be True    ${dest_match_found}
 
 Add a public mailbox address alias
     Run task    module/${MID}/add-address    {"atype":"domain","local":"mailadm","domain":"${test_domain}","destinations":[{"dtype":"public","name":"vmail+postmaster"}]}

--- a/tests/ldap_providers.resource
+++ b/tests/ldap_providers.resource
@@ -23,6 +23,8 @@ Configure AD user domain
     Run task    module/${mid_ad}/add-group   {"group":"g2","description":"Group Two","users":["u2","u3"]}
     Run task    module/${mid_ad}/add-user    {"user":"ucatchall","display_name":"Catch All User","password":"Nethesis,1234"}
     Run task    module/${mid_ad}/add-group      {"group":"info","description":"Info Group","users":["u1","u2"]}
+    Run task    module/${mid_ad}/add-user    {"user":"MixedCaseUser","display_name":"Mixed Case User","password":"Nethesis,1234"}
+    Run task    module/${mid_ad}/add-group   {"group":"MixedCaseGroup","description":"Mixed Case Group","users":["MixedCaseUser"]}
 
 Configure LDAP user domain
     [Tags]    udom    add    ldap
@@ -37,6 +39,8 @@ Configure LDAP user domain
     Run task    module/${mid_ldap}/add-user    {"user":"ucatchall","display_name":"Catch All User","password":"Nethesis,1234"}
     Run task    module/${mid_ldap}/add-user       {"user":"info","display_name":"Info User","password":"Nethesis,1234"}
     Run task    module/${mid_ldap}/add-group      {"group":"info","description":"Info Group","users":["u1","u2"]}
+    Run task    module/${mid_ldap}/add-user    {"user":"MixedCaseUser","display_name":"Mixed Case User","password":"Nethesis,1234"}
+    Run task    module/${mid_ldap}/add-group   {"group":"MixedCaseGroup","description":"Mixed Case Group","users":["MixedCaseUser"]}
 
 Remove AD user domain
     [Tags]    udom    remove    ad


### PR DESCRIPTION
## Summary
- `list-destinations` returned AD/OpenLDAP user and group names in their original LDAP case, while `list-addresses` (via `mail.py`'s `DestEncoder`) always lower-cases them.
- The frontend address destination selector matches the two by an exact `name_dtype` string, so any mixed-case LDAP/AD account made it fail to resolve a real mailbox/group destination, silently treating it as free-text external instead.
- Lower-case `name` for `user`/`group` entries in `list-destinations` to match, and add a Robot Framework test with a mixed-case AD/OpenLDAP user and group to cover it.

For context: the casing convention (lower-casing for Dovecot compatibility, since AD/OpenLDAP are case-insensitive but Dovecot isn't) was introduced in 6627b3b ("api. Force lowercase of group and user names", 2023), but that fix only touched `mail.py` — `list-destinations` is a separate action script and was missed, which is the root cause of this regression.

NethServer/dev#8074

## Test plan
- [x] Added Robot Framework test cases in `tests/40__api/20__addresses.robot` covering mixed-case AD/OpenLDAP user and group destinations
- [x] Full test suite run passes