### PR TITLE
fix(clamav): pass cus rating via helper argument

### DIFF
--- a/clamav/README.md
+++ b/clamav/README.md
@@ -11,10 +11,7 @@ Well-known ports
 
 ## Environment variables
 
-- `CLAMAV_CUS_RATING` Value for clamav-unofficial-sigs parameter
-  `default_dbs_rating`. Value must be one of `LOW`, `MEDIUM` (the
-  default), `HIGH`, `DISABLE`. See official documentation for the meaning
-  of those values. The default value is highly recommended.
+None
 
 ## Volumes
 
@@ -30,11 +27,17 @@ Well-known ports
 ## Commands
 
 - `download-sigs` Download signatures with one of the available methods:
-     1. `cus` (clamav-unofficial-sigs)
+     1. `cus`, `cus-low`, `cus-medium`, `cus-high`, `cus-disable`
+        (clamav-unofficial-sigs)
      2. `freshclam` (Freshclam)
 
-  Method name is passed as first command argument. Additional arguments are passed to the downloader executable.
+  Method name is passed as first command argument. Additional arguments
+  are passed to the downloader executable. The `cus-*` variants implicitly
+  invoke `set-cus-rating` before the download starts to adjust the rating
+  configuration.
 
 - `set-cus-rating` This command sets the value of `default_dbs_rating` in
-  the `user.conf` file. Pass the value (e.g. `LOW`) as the first argument
-  to the command.
+  the `user.conf` file. Pass the value (e.g. `LOW`, `MEDIUM`, `HIGH` or
+  `DISABLE`) as the first argument to the command. See the
+  clamav-unofficial-sigs documentation for the meaning of those values;
+  `MEDIUM` is the recommended default.

--- a/clamav/usr/local/sbin/download-sigs
+++ b/clamav/usr/local/sbin/download-sigs
@@ -20,11 +20,19 @@ if [ "${sig_type}" = "freshclam" ]; then
     exec /usr/bin/freshclam "${@}"
 fi
 
-if [ "${sig_type}" = "cus" ]; then
-    if [ -n "${CLAMAV_CUS_RATING}" ]; then
-        # Apply rating value to user.conf
-        set-cus-rating "${CLAMAV_CUS_RATING}"
-    fi
-    # Start clamav-unofficial-sigs
-    exec su -s /bin/bash - clamav /usr/local/sbin/clamav-unofficial-sigs.sh -- "${@}"
-fi
+sig_type_lc=$(printf '%s' "${sig_type}" | tr 'A-Z' 'a-z')
+
+case "${sig_type_lc}" in
+    cus*)
+        case "${sig_type_lc}" in
+            cus-*)
+                # Change configured rating value in user.conf before starting
+                # the download process. If sig_type has no rating suffix, do
+                # not touch it.
+                set-cus-rating "${sig_type_lc#cus-}"
+                ;;
+        esac
+        # Start clamav-unofficial-sigs
+        exec su -s /bin/bash - clamav /usr/local/sbin/clamav-unofficial-sigs.sh -- "${@}"
+        ;;
+esac

--- a/clamav/usr/local/sbin/set-cus-rating
+++ b/clamav/usr/local/sbin/set-cus-rating
@@ -8,5 +8,8 @@
 # shellcheck shell=dash
 set -e
 
-sed  "/^default_dbs_rating=/ c \default_dbs_rating=\"${CLAMAV_CUS_RATING:?}\"" \
+rating=${1:?missing rating argument}
+rating=$(printf '%s' "${rating}" | tr 'a-z' 'A-Z')
+
+sed  "/^default_dbs_rating=/ c \default_dbs_rating=\"${rating}\"" \
     /etc/clamav-unofficial-sigs/user.conf

--- a/clamav/usr/local/sbin/set-cus-rating
+++ b/clamav/usr/local/sbin/set-cus-rating
@@ -11,5 +11,6 @@ set -e
 rating=${1:?missing rating argument}
 rating=$(printf '%s' "${rating}" | tr 'a-z' 'A-Z')
 
-sed  "/^default_dbs_rating=/ c \default_dbs_rating=\"${rating}\"" \
+sed -i "/^default_dbs_rating=/ c \default_dbs_rating=\"${rating}\"" \
+    /etc/clamav-unofficial-sigs/user.conf
     /etc/clamav-unofficial-sigs/user.conf

--- a/clamav/usr/local/sbin/set-cus-rating
+++ b/clamav/usr/local/sbin/set-cus-rating
@@ -13,4 +13,3 @@ rating=$(printf '%s' "${rating}" | tr 'a-z' 'A-Z')
 
 sed -i "/^default_dbs_rating=/ c \default_dbs_rating=\"${rating}\"" \
     /etc/clamav-unofficial-sigs/user.conf
-    /etc/clamav-unofficial-sigs/user.conf

--- a/imageroot/systemd/user/clamav-unofficial-sigs.service
+++ b/imageroot/systemd/user/clamav-unofficial-sigs.service
@@ -5,6 +5,8 @@ After=clamav.service
 
 [Service]
 Type=oneshot
-ExecStart=podman exec clamav download-sigs cus -s
+Environment=CLAMAV_CUS_RATING=MEDIUM
+EnvironmentFile=%E/state/environment
+ExecStart=podman exec clamav download-sigs cus-${CLAMAV_CUS_RATING} -s
 WorkingDirectory=%E/state
 SyslogIdentifier=%N


### PR DESCRIPTION
## Summary

The `CLAMAV_CUS_RATING` environment variable set on the systemd
service never reached the `podman exec`'d helper scripts inside the
`clamav` container, so the custom signature rating configured by the
module was silently ignored. This passes the rating as a `cus-<rating>`
argument to `download-sigs` instead, since systemd substitutes
`${CLAMAV_CUS_RATING}` directly into the `ExecStart` command line
before `podman exec` runs.

## Related issue

NethServer/dev#8115

## How to test

1. Set the third-party signature rating to a non-default value (e.g.
   `HIGH`) from the mail module UI.
2. Run `systemctl --user start clamav-unofficial-sigs.service`.
3. Check `/etc/clamav-unofficial-sigs/user.conf` inside the `clamav`
   container: `default_dbs_rating` should now match the configured
   value.